### PR TITLE
fix: parent ignore files must be enabled

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -60,7 +60,6 @@ pub fn find_sol_files<T: AsRef<Path>>(paths: &[T], exclude: &[T]) -> Result<Vec<
     };
     walker
         .hidden(false)
-        .parents(false)
         .git_global(false)
         .git_exclude(false)
         .add_custom_ignore_filename(".nsignore")


### PR DESCRIPTION
This makes it so that a project can have a `.nsignore` file at the root and pass `src` as a path to scan. Otherwise any ignore file above `src` is ignored.