### PR TITLE
refactor(definitions): replace macro with function

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739451785,
-        "narHash": "sha256-3ebRdThRic9bHMuNi2IAA/ek9b32bsy8F5R4SvGTIog=",
+        "lastModified": 1740019556,
+        "narHash": "sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1128e89fd5e11bb25aedbfc287733c6502202ea9",
+        "rev": "dad564433178067be1fbdfcce23b546254b6d641",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739500069,
-        "narHash": "sha256-eCxWMqMsP2KQkleWWhs9KzFvxgd9v0F0iq7Piw6XDAs=",
+        "lastModified": 1740104932,
+        "narHash": "sha256-FaN+HBAhOW1wAjxPI/Ko1DX0ax4ucHCZoMJ0dGMxm8o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "cd3e0a87bf9edadb0f311ba1eb677bbae7a08b81",
+        "rev": "c932b3873a5d56126bc1f1416fb8a58315f86c17",
         "type": "github"
       },
       "original": {

--- a/src/definitions/constructor.rs
+++ b/src/definitions/constructor.rs
@@ -45,8 +45,8 @@ impl Validate for ConstructorDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let constructor = capture!(m, "constructor");
-        let params = capture!(m, "constructor_params");
+        let constructor = capture(&m, "constructor")?;
+        let params = capture(&m, "constructor_params")?;
 
         let span = params.text_range();
         let params = extract_params(params, NonterminalKind::Parameter);

--- a/src/definitions/enumeration.rs
+++ b/src/definitions/enumeration.rs
@@ -45,9 +45,9 @@ impl Validate for EnumDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let enumeration = capture!(m, "enum");
-        let name = capture!(m, "enum_name");
-        let members = capture!(m, "enum_members");
+        let enumeration = capture(&m, "enum")?;
+        let name = capture(&m, "enum_name")?;
+        let members = capture(&m, "enum_members")?;
 
         let span = enumeration.text_range();
         let name = name.node().unparse().trim().to_string();

--- a/src/definitions/error.rs
+++ b/src/definitions/error.rs
@@ -45,9 +45,9 @@ impl Validate for ErrorDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let err = capture!(m, "err");
-        let name = capture!(m, "err_name");
-        let params = capture!(m, "err_params");
+        let err = capture(&m, "err")?;
+        let name = capture(&m, "err_name")?;
+        let params = capture(&m, "err_params")?;
 
         let span = err.text_range();
         let name = name.node().unparse().trim().to_string();

--- a/src/definitions/event.rs
+++ b/src/definitions/event.rs
@@ -45,9 +45,9 @@ impl Validate for EventDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let event = capture!(m, "event");
-        let name = capture!(m, "event_name");
-        let params = capture!(m, "event_params");
+        let event = capture(&m, "event")?;
+        let name = capture(&m, "event_name")?;
+        let params = capture(&m, "event_params")?;
 
         let span = event.text_range();
         let name = name.node().unparse().trim().to_string();

--- a/src/definitions/function.rs
+++ b/src/definitions/function.rs
@@ -1,15 +1,15 @@
 use slang_solidity::cst::{NonterminalKind, Query, QueryMatch, TextRange};
 
 use crate::{
-    error::{Error, Result},
+    error::Result,
     lint::{Diagnostic, ItemDiagnostics, ItemType},
     natspec::{NatSpec, NatSpecKind},
 };
 
 use super::{
-    capture, check_params, check_returns, extract_attributes, extract_comment, extract_params,
-    extract_parent_name, Attributes, Definition, Identifier, Parent, Validate, ValidationOptions,
-    Visibility,
+    capture, capture_opt, check_params, check_returns, extract_attributes, extract_comment,
+    extract_params, extract_parent_name, Attributes, Definition, Identifier, Parent, Validate,
+    ValidationOptions, Visibility,
 };
 
 /// A function definition
@@ -70,19 +70,12 @@ impl Validate for FunctionDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let func = capture!(m, "function");
-        let keyword = capture!(m, "keyword");
-        let name = capture!(m, "function_name");
-        let params = capture!(m, "function_params");
-        let attributes = capture!(m, "function_attr");
-        let returns = match m
-            .capture("function_returns")
-            .map(|(_, mut captures)| captures.next())
-        {
-            Some(Some(ret)) => Some(ret),
-            Some(None) => None,
-            _ => return Err(Error::UnknownError),
-        };
+        let func = capture(&m, "function")?;
+        let keyword = capture(&m, "keyword")?;
+        let name = capture(&m, "function_name")?;
+        let params = capture(&m, "function_params")?;
+        let attributes = capture(&m, "function_attr")?;
+        let returns = capture_opt(&m, "function_returns")?;
 
         let span = if let Some(returns) = &returns {
             keyword.text_range().start..returns.text_range().end

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -28,18 +28,21 @@ pub mod structure;
 pub mod variable;
 
 /// Retrieve and unwrap the first capture of a parser match, or return with an [`Error`]
-macro_rules! capture {
-    ($m:ident, $name:expr) => {
-        match $m.capture($name).map(|(_, mut captures)| captures.next()) {
-            Some(Some(res)) => res,
-            _ => {
-                return Err($crate::error::Error::UnknownError);
-            }
-        }
-    };
+pub fn capture(m: &QueryMatch, name: &str) -> Result<Cursor> {
+    match m.capture(name).map(|(_, mut captures)| captures.next()) {
+        Some(Some(res)) => Ok(res),
+        _ => Err(Error::UnknownError),
+    }
 }
 
-pub(crate) use capture;
+/// Retrieve and unwrap the first capture of a parser match if one exists.
+pub fn capture_opt(m: &QueryMatch, name: &str) -> Result<Option<Cursor>> {
+    match m.capture(name).map(|(_, mut captures)| captures.next()) {
+        Some(Some(res)) => Ok(Some(res)),
+        Some(None) => Ok(None),
+        _ => Err(Error::UnknownError),
+    }
+}
 
 /// Validation options to control which lints generate a diagnostic
 #[derive(Debug, Clone)]

--- a/src/definitions/modifier.rs
+++ b/src/definitions/modifier.rs
@@ -1,14 +1,14 @@
 use slang_solidity::cst::{NonterminalKind, Query, QueryMatch, TextRange};
 
 use crate::{
-    error::{Error, Result},
+    error::Result,
     lint::{Diagnostic, ItemDiagnostics, ItemType},
     natspec::{NatSpec, NatSpecKind},
 };
 
 use super::{
-    capture, check_params, extract_comment, extract_params, extract_parent_name, Definition,
-    Identifier, Parent, Validate, ValidationOptions,
+    capture, capture_opt, check_params, extract_comment, extract_params, extract_parent_name,
+    Definition, Identifier, Parent, Validate, ValidationOptions,
 };
 
 /// A modifier definition
@@ -48,17 +48,10 @@ impl Validate for ModifierDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let modifier = capture!(m, "modifier");
-        let name = capture!(m, "modifier_name");
-        let params = match m
-            .capture("modifier_params")
-            .map(|(_, mut captures)| captures.next())
-        {
-            Some(Some(ret)) => Some(ret),
-            Some(None) => None,
-            _ => return Err(Error::UnknownError),
-        };
-        let attr = capture!(m, "modifier_attr");
+        let modifier = capture(&m, "modifier")?;
+        let name = capture(&m, "modifier_name")?;
+        let params = capture_opt(&m, "modifier_params")?;
+        let attr = capture(&m, "modifier_attr")?;
 
         let span = if let Some(params) = &params {
             name.text_range().start..params.text_range().end

--- a/src/definitions/structure.rs
+++ b/src/definitions/structure.rs
@@ -45,9 +45,9 @@ impl Validate for StructDefinition {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let structure = capture!(m, "struct");
-        let name = capture!(m, "struct_name");
-        let members = capture!(m, "struct_members");
+        let structure = capture(&m, "struct")?;
+        let name = capture(&m, "struct_name")?;
+        let members = capture(&m, "struct_members")?;
 
         let span = structure.text_range();
         let name = name.node().unparse().trim().to_string();
@@ -96,7 +96,7 @@ fn extract_struct_members(cursor: Cursor) -> Result<Vec<Identifier>> {
     )
     .expect("query should compile");
     for m in cursor.query(vec![query]) {
-        let member_name = capture!(m, "member_name");
+        let member_name = capture(&m, "member_name")?;
         out.push(Identifier {
             name: Some(member_name.node().unparse().trim().to_string()),
             span: member_name.text_range(),

--- a/src/definitions/variable.rs
+++ b/src/definitions/variable.rs
@@ -54,10 +54,10 @@ impl Validate for VariableDeclaration {
     }
 
     fn extract(m: QueryMatch) -> Result<Definition> {
-        let variable = capture!(m, "variable");
-        let var_type = capture!(m, "variable_type");
-        let attributes = capture!(m, "variable_attr");
-        let name = capture!(m, "variable_name");
+        let variable = capture(&m, "variable")?;
+        let var_type = capture(&m, "variable_type")?;
+        let attributes = capture(&m, "variable_attr")?;
+        let name = capture(&m, "variable_name")?;
 
         let span = var_type.text_range().start..variable.text_range().end;
         let name = name.node().unparse().trim().to_string();


### PR DESCRIPTION
The macro was required when it was being called in a loop to have the `continue` statement. But now that it returns an error, we can simply use a normal function.