### PR TITLE
fix(definitions): comments filtering

### DIFF
--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -165,6 +165,13 @@ pub enum Definition {
 }
 
 impl PartialEq for Definition {
+    /// Compare two definitions based on their underlying node
+    ///
+    /// If two instances of the same node generate two definitions (due to quantifiers in the query), this can be
+    /// used to deduplicate the instances.
+    ///
+    /// TODO: is the usage of the span start fine here, or should we instead rely on the `id()` of the node? It would
+    /// require adding a field in the definition just for that.
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Constructor(a), Self::Constructor(b)) => a.span.start == b.span.start,

--- a/test-data/ParserTest.sol
+++ b/test-data/ParserTest.sol
@@ -156,14 +156,26 @@ contract ParserTestFunny is IParserTest {
    *
    *
    * 
-   * I met Obama once
-   * She's cool
+   * This should be ignored
    */
 
+  /**
+   * @notice   Some private stuff
+   * @param      _paramName The parameter name
+   * @return     _returned     The returned value
+   */
+  function _viewPrivateMulti(uint256 _paramName) private pure returns (uint256 _returned) {
+    return 1;
+  }
+
+  /// @dev This should be ignored
+  /**
+    * @dev this too
+    */
   /// @notice   Some private stuff
   /// @param      _paramName The parameter name
   /// @return     _returned     The returned value
-  function _viewPrivate(uint256 _paramName) private pure returns (uint256 _returned) {
+  function _viewPrivateSingle(uint256 _paramName) private pure returns (uint256 _returned) {
     return 1;
   }
 


### PR DESCRIPTION
According to the rules implemented by solc, the only comments that constitute NatSpec are:
- The last multiline doc-comment before a definition
- The block of last contiguous single-line doc-comments before a definition

```solidity
/// @dev This should be ignored
/**
  * @dev This should be ignored
  */
/// @notice  This is NatSpec
/// @param a This is NatSpec
function foo(uint256 a) internal { }

/// @dev This should be ignored

/// @notice  This is NatSpec
/// @param a This is NatSpec
function foo(uint256 a) internal { }

/**
 * @dev This should be ignored
 */
/**
 * @notice This is NatSpec
 * @param a This is NatSpec
 */
function foo(uint256 a) internal { }

```