### PR TITLE
refactor(definitions)!: conversion functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +382,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,11 @@ pedantic = { level = "warn", priority = -1 }
 anyhow = "1.0.95"
 bon = "3.3.2"
 clap = { version = "4.5.29", features = ["derive"] }
-derive_more = { version = "2.0.1", features = ["from", "display"] }
+derive_more = { version = "2.0.1", features = [
+    "from",
+    "display",
+    "is_variant",
+] }
 dotenvy = "0.15.7"
 dunce = "1.0.5"
 figment = { version = "0.10.19", features = ["env", "toml"] }

--- a/src/definitions/constructor.rs
+++ b/src/definitions/constructor.rs
@@ -126,7 +126,7 @@ mod tests {
             .next()
             .unwrap();
         let def = ConstructorDefinition::extract(m).unwrap();
-        def.as_constructor().unwrap()
+        def.to_constructor().unwrap()
     }
 
     #[test]

--- a/src/definitions/enumeration.rs
+++ b/src/definitions/enumeration.rs
@@ -140,7 +140,7 @@ mod tests {
         let cursor = output.create_tree_cursor();
         let m = cursor.query(vec![EnumDefinition::query()]).next().unwrap();
         let def = EnumDefinition::extract(m).unwrap();
-        def.as_enum().unwrap()
+        def.to_enum().unwrap()
     }
 
     #[test]

--- a/src/definitions/error.rs
+++ b/src/definitions/error.rs
@@ -124,7 +124,7 @@ mod tests {
         let cursor = output.create_tree_cursor();
         let m = cursor.query(vec![ErrorDefinition::query()]).next().unwrap();
         let def = ErrorDefinition::extract(m).unwrap();
-        def.as_error().unwrap()
+        def.to_error().unwrap()
     }
 
     #[test]

--- a/src/definitions/event.rs
+++ b/src/definitions/event.rs
@@ -124,7 +124,7 @@ mod tests {
         let cursor = output.create_tree_cursor();
         let m = cursor.query(vec![EventDefinition::query()]).next().unwrap();
         let def = EventDefinition::extract(m).unwrap();
-        def.as_event().unwrap()
+        def.to_event().unwrap()
     }
 
     #[test]

--- a/src/definitions/function.rs
+++ b/src/definitions/function.rs
@@ -204,7 +204,7 @@ mod tests {
             .next()
             .unwrap();
         let def = FunctionDefinition::extract(m).unwrap();
-        def.as_function().unwrap()
+        def.to_function().unwrap()
     }
 
     #[test]

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -238,72 +238,143 @@ impl Definition {
         }
     }
 
-    /// Retrieve the inner constructor definition
+    /// Convert to the inner constructor definition
     #[must_use]
-    pub fn as_constructor(self) -> Option<ConstructorDefinition> {
+    pub fn to_constructor(self) -> Option<ConstructorDefinition> {
         match self {
             Definition::Constructor(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner enum definition
+    /// Convert to the inner enum definition
     #[must_use]
-    pub fn as_enum(self) -> Option<EnumDefinition> {
+    pub fn to_enum(self) -> Option<EnumDefinition> {
         match self {
             Definition::Enumeration(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner error definition
+    /// Convert to the inner error definition
     #[must_use]
-    pub fn as_error(self) -> Option<ErrorDefinition> {
+    pub fn to_error(self) -> Option<ErrorDefinition> {
         match self {
             Definition::Error(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner event definition
+    /// Convert to the inner event definition
     #[must_use]
-    pub fn as_event(self) -> Option<EventDefinition> {
+    pub fn to_event(self) -> Option<EventDefinition> {
         match self {
             Definition::Event(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner function definition
+    /// Convert to the inner function definition
     #[must_use]
-    pub fn as_function(self) -> Option<FunctionDefinition> {
+    pub fn to_function(self) -> Option<FunctionDefinition> {
         match self {
             Definition::Function(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner modifier definition
+    /// Convert to the inner modifier definition
     #[must_use]
-    pub fn as_modifier(self) -> Option<ModifierDefinition> {
+    pub fn to_modifier(self) -> Option<ModifierDefinition> {
         match self {
             Definition::Modifier(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner struct definition
+    /// Convert to the inner struct definition
     #[must_use]
-    pub fn as_struct(self) -> Option<StructDefinition> {
+    pub fn to_struct(self) -> Option<StructDefinition> {
         match self {
             Definition::Struct(def) => Some(def),
             _ => None,
         }
     }
 
-    /// Retrieve the inner variable declaration
+    /// Convert to the inner variable declaration
     #[must_use]
-    pub fn as_variable(self) -> Option<VariableDeclaration> {
+    pub fn to_variable(self) -> Option<VariableDeclaration> {
+        match self {
+            Definition::Variable(def) => Some(def),
+            _ => None,
+        }
+    }
+    /// Reference to the inner constructor definition
+    #[must_use]
+    pub fn as_constructor(&self) -> Option<&ConstructorDefinition> {
+        match self {
+            Definition::Constructor(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner enum definition
+    #[must_use]
+    pub fn as_enum(&self) -> Option<&EnumDefinition> {
+        match self {
+            Definition::Enumeration(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner error definition
+    #[must_use]
+    pub fn as_error(&self) -> Option<&ErrorDefinition> {
+        match self {
+            Definition::Error(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner event definition
+    #[must_use]
+    pub fn as_event(&self) -> Option<&EventDefinition> {
+        match self {
+            Definition::Event(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner function definition
+    #[must_use]
+    pub fn as_function(&self) -> Option<&FunctionDefinition> {
+        match self {
+            Definition::Function(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner modifier definition
+    #[must_use]
+    pub fn as_modifier(&self) -> Option<&ModifierDefinition> {
+        match self {
+            Definition::Modifier(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner struct definition
+    #[must_use]
+    pub fn as_struct(&self) -> Option<&StructDefinition> {
+        match self {
+            Definition::Struct(def) => Some(def),
+            _ => None,
+        }
+    }
+
+    /// Reference to the inner variable declaration
+    #[must_use]
+    pub fn as_variable(&self) -> Option<&VariableDeclaration> {
         match self {
             Definition::Variable(def) => Some(def),
             _ => None,

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -6,7 +6,7 @@
 //! definitions contained within.
 //! Some helper functions allow to extract useful information from [`Cursor`]s.
 use constructor::ConstructorDefinition;
-use derive_more::{Display, From};
+use derive_more::{Display, From, IsVariant};
 use enumeration::EnumDefinition;
 use error::ErrorDefinition;
 use event::EventDefinition;
@@ -169,7 +169,7 @@ pub enum Parent {
 }
 
 /// A source item's definition
-#[derive(Debug, From)]
+#[derive(Debug, From, IsVariant)]
 pub enum Definition {
     Constructor(ConstructorDefinition),
     Enumeration(EnumDefinition),

--- a/src/definitions/modifier.rs
+++ b/src/definitions/modifier.rs
@@ -178,7 +178,7 @@ mod tests {
             .next()
             .unwrap();
         let def = ModifierDefinition::extract(m).unwrap();
-        def.as_modifier().unwrap()
+        def.to_modifier().unwrap()
     }
 
     #[test]

--- a/src/definitions/structure.rs
+++ b/src/definitions/structure.rs
@@ -150,7 +150,7 @@ mod tests {
             .next()
             .unwrap();
         let def = StructDefinition::extract(m).unwrap();
-        def.as_struct().unwrap()
+        def.to_struct().unwrap()
     }
 
     #[test]

--- a/src/definitions/variable.rs
+++ b/src/definitions/variable.rs
@@ -155,7 +155,7 @@ mod tests {
             .next()
             .unwrap();
         let def = VariableDeclaration::extract(m).unwrap();
-        def.as_variable().unwrap()
+        def.to_variable().unwrap()
     }
 
     #[test]


### PR DESCRIPTION
`as_...()` were renamed to `to_...()` because they consume the input. Added `as_...()` that takes in a reference and returns a reference.