### PR TITLE
chore: remove useless feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ derive_more = { version = "2.0.1", features = [
 dotenvy = "0.15.7"
 dunce = "1.0.5"
 figment = { version = "0.10.19", features = ["env", "toml"] }
-ignore = { version = "0.4.23", features = ["simd-accel"] }
+ignore = "0.4.23"
 miette = { version = "7.5.0", features = ["fancy"] }
 rayon = "1.10.0"
 regex = "1.11.1"


### PR DESCRIPTION
SIMD is done automatically in `ignore`, feature is a no-op.