### PR TITLE
docs: pin action version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The following options are available for the action (all are optional if a config
 | `paths` | `"[]"` | Paths to scan, relative to the working directory, in square brackets and separated by commas. Required unless a `.lintspec.toml` file is present in the working directory. | `"[path/to/file.sol,test/test.sol]"` |
 | `exclude` | `"[]"` | Paths to exclude, relative to the working directory, in square brackets and separated by commas | `"[path/to/exclude,other/path.sol]"` | 
 | `extra-args` | | Extra arguments passed to the `lintspec` command | `"--constructor=true"` |
-| `version` | `"latest"` | Version of lintspec to use. For enhanced security, you can pin this to a fixed version | `"0.1.5"` |
+| `version` | `"latest"` | Version of lintspec to use. For enhanced security, you can pin this to a fixed version | `"0.4.1"` |
 | `fail-on-problem` | `"true"` | Whether the action should fail when `NatSpec` problems have been found. Disabling this only creates annotations for found problems, but succeeds | `"false"` |
 
 ### Example Workflow

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: beeb/lintspec@main
+      - uses: beeb/lintspec@v0.4.1
         # all the lines below are optional
         with:
           working-directory: "./"

--- a/README.md
+++ b/README.md
@@ -223,4 +223,5 @@ Summary
 | JSON output                     | ✅          | ❌                |
 | Output to file                  | ✅          | ❌                |
 | Multithreaded                   | ✅          | ❌                |
+| Built-in CI action              | ✅          | ❌                |
 | No pre-requisites (node/npm)    | ✅          | ❌                |


### PR DESCRIPTION
It's probably better if people depend on a fixed version of the action.