### PR TITLE
feat!: allow to skip solidity version detection

### DIFF
--- a/.lintspec.toml
+++ b/.lintspec.toml
@@ -1,8 +1,9 @@
 [lintspec]
-paths = []            # paths to files and folders to analyze
-exclude = []          # paths to files or folders to exclude, see also `.nsignore`
-inheritdoc = true     # enforce that all overridden, public and external items have `@inheritdoc`
-notice_or_dev = false # do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+paths = []                     # paths to files and folders to analyze
+exclude = []                   # paths to files or folders to exclude, see also `.nsignore`
+inheritdoc = true              # enforce that all overridden, public and external items have `@inheritdoc`
+notice_or_dev = false          # do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+skip_version_detection = false # skip detection of the Solidity version from pragma statements and use the latest
 
 [output]
 # out = ""        # if provided, redirects output to this file

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Options:
   -o, --out <OUT>                Write output to a file instead of stderr
       --inheritdoc               Enforce that all public and external items have `@inheritdoc`
       --notice-or-dev            Do not distinguish between `@notice` and `@dev` when considering "required" validation rules
+      --skip-version-detection   Skip the detection of the Solidity version from pragma statements
       --notice-ignored <TYPE>    Ignore `@notice` for these items (can be used more than once)
       --notice-required <TYPE>   Enforce `@notice` for these items (can be used more than once)
       --notice-forbidden <TYPE>  Forbid `@notice` for these items (can be used more than once)

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,7 +282,7 @@ pub struct BaseConfig {
     #[builder(default)]
     pub notice_or_dev: bool,
 
-    /// Skip the detection of the Solidity version and use the latest version supported by [`slang_solididty`]
+    /// Skip the detection of the Solidity version and use the latest version supported by [`slang_solidity`]
     #[builder(default)]
     pub skip_version_detection: bool,
 }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -106,15 +106,13 @@ pub struct Diagnostic {
 /// provided, and a compatible Solidity version will be inferred from the first version pragma statement (if any) to
 /// inform the parsing. [`ValidationOptions`] can be provided to control whether some of the lints get reported.
 /// The `keep_contents` parameter controls if the returned [`FileDiagnostics`] contains the original source code.
-pub fn lint<T>(
+pub fn lint(
+    mut parser: impl Parse,
     path: impl AsRef<Path>,
     options: &ValidationOptions,
     keep_contents: bool,
-) -> Result<Option<FileDiagnostics>>
-where
-    T: Parse,
-{
-    let document = T::parse_document(&path, keep_contents)?;
+) -> Result<Option<FileDiagnostics>> {
+    let document = parser.parse_document(&path, keep_contents)?;
     let mut items: Vec<_> = document
         .definitions
         .into_iter()
@@ -201,6 +199,24 @@ impl Default for ValidationOptions {
             modifiers: WithParamsRules::required(),
             structs: WithParamsRules::default(),
             variables: VariableConfig::default(),
+        }
+    }
+}
+
+/// Create a [`ValidationOptions`] from a [`Config`]
+impl From<Config> for ValidationOptions {
+    fn from(value: Config) -> Self {
+        Self {
+            inheritdoc: value.lintspec.inheritdoc,
+            notice_or_dev: value.lintspec.notice_or_dev,
+            constructors: value.constructors,
+            enums: value.enums,
+            errors: value.errors,
+            events: value.events,
+            functions: value.functions,
+            modifiers: value.modifiers,
+            structs: value.structs,
+            variables: value.variables,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,12 +37,20 @@ fn main() -> Result<()> {
 
     // lint all the requested Solidity files
     let options: ValidationOptions = (&config).into();
+    let parser = SlangParser::builder()
+        .skip_version_detection(config.lintspec.skip_version_detection)
+        .build();
     let diagnostics = paths
         .par_iter()
         .filter_map(|p| {
-            lint::<SlangParser>(p, &options, !config.output.compact && !config.output.json)
-                .map_err(Into::into)
-                .transpose()
+            lint(
+                parser.clone(),
+                p,
+                &options,
+                !config.output.compact && !config.output.json,
+            )
+            .map_err(Into::into)
+            .transpose()
         })
         .collect::<Result<Vec<_>>>()?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,6 +6,7 @@ use crate::{definitions::Definition, error::Result};
 pub mod slang;
 
 /// The result of parsing and identifying source items in a document
+#[derive(Debug)]
 pub struct ParsedDocument {
     /// The list of definitions found in the document
     pub definitions: Vec<Definition>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,5 +17,11 @@ pub struct ParsedDocument {
 /// The trait implemented by all parsers
 pub trait Parse {
     /// Parse a document at `path` and identify the relevant source items
-    fn parse_document(path: impl AsRef<Path>, keep_contents: bool) -> Result<ParsedDocument>;
+    ///
+    /// The fact that this takes in a mutable reference to the parser allows for stateful parsers.
+    fn parse_document(
+        &mut self,
+        path: impl AsRef<Path>,
+        keep_contents: bool,
+    ) -> Result<ParsedDocument>;
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -1282,4 +1282,11 @@ mod tests {
         let output = parser.parse(NonterminalKind::SourceUnit, contents);
         assert!(output.is_valid(), "{:?}", output.errors());
     }
+
+    #[test]
+    fn test_parse_solidity_unsupported() {
+        let mut parser = SlangParser::builder().skip_version_detection(true).build();
+        let output = parser.parse_document("test-data/UnsupportedVersion.sol", false);
+        assert!(output.is_ok(), "{output:?}");
+    }
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -102,6 +102,11 @@ impl Parse for SlangParser {
                 path: path.as_ref().to_path_buf(),
                 err,
             })?;
+            // let solidity_version = if self.skip_version_detection {
+            //     get_latest_supported_version()
+            // } else {
+            //     detect_solidity_version(&contents)?
+            // };
             let solidity_version = detect_solidity_version(&contents)?;
             let parser = Parser::create(solidity_version).expect("parser should initialize");
             let output = parser.parse(NonterminalKind::SourceUnit, &contents);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,13 +58,8 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
         return Ok(Version::new(0, 8, 0));
     };
 
-    let parser = Parser::create(
-        Parser::SUPPORTED_VERSIONS
-            .last()
-            .expect("the SUPPORTED_VERSIONS list should not be empty")
-            .to_owned(),
-    )
-    .expect("the Parser should be initialized correctly with a supported solidity version");
+    let parser = Parser::create(get_latest_supported_version())
+        .expect("the Parser should be initialized correctly with a supported solidity version");
 
     let parse_result = parser.parse(NonterminalKind::PragmaDirective, pragma.as_str());
     if !parse_result.is_valid() {
@@ -136,4 +131,13 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
         .max()
         .cloned()
         .ok_or_else(|| Error::SolidityUnsupportedVersion(pragma.as_str().to_string()))
+}
+
+/// Get the latest Solidity version supported by the [`slang_solidity`] parser
+#[must_use]
+pub fn get_latest_supported_version() -> Version {
+    Parser::SUPPORTED_VERSIONS
+        .last()
+        .expect("the SUPPORTED_VERSIONS list should not be empty")
+        .to_owned()
 }

--- a/test-data/UnsupportedVersion.sol
+++ b/test-data/UnsupportedVersion.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.1234;
+
+contract UnsupportedVersion {}

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -15,7 +15,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
@@ -27,7 +28,8 @@ fn test_basic() {
 
 #[test]
 fn test_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::default(),
         true,
@@ -39,7 +41,8 @@ fn test_inheritdoc() {
 
 #[test]
 fn test_constructor() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -54,7 +57,8 @@ fn test_constructor() {
 
 #[test]
 fn test_struct() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -69,7 +73,8 @@ fn test_struct() {
 
 #[test]
 fn test_enum() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -84,7 +89,8 @@ fn test_enum() {
 
 #[test]
 fn test_all() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .constructors(WithParamsRules::required())
@@ -117,7 +123,8 @@ fn test_all() {
 
 #[test]
 fn test_all_no_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)

--- a/tests/tests-interface-sample.rs
+++ b/tests/tests-interface-sample.rs
@@ -5,7 +5,8 @@ use lintspec::{
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/InterfaceSample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,

--- a/tests/tests-library-sample.rs
+++ b/tests/tests-library-sample.rs
@@ -14,7 +14,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/LibrarySample.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,

--- a/tests/tests-parser-test.rs
+++ b/tests/tests-parser-test.rs
@@ -15,7 +15,8 @@ fn generate_output(diags: FileDiagnostics) -> String {
 
 #[test]
 fn test_basic() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder().inheritdoc(false).build(),
         true,
@@ -27,7 +28,8 @@ fn test_basic() {
 
 #[test]
 fn test_inheritdoc() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::default(),
         true,
@@ -39,7 +41,8 @@ fn test_inheritdoc() {
 
 #[test]
 fn test_constructor() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -54,7 +57,8 @@ fn test_constructor() {
 
 #[test]
 fn test_struct() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
@@ -69,7 +73,8 @@ fn test_struct() {
 
 #[test]
 fn test_enum() {
-    let diags = lint::<SlangParser>(
+    let diags = lint(
+        SlangParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)


### PR DESCRIPTION
This PR adds the option to skip the solidity version detection from pragma statements. This would be useful for users who would like to use a `lintspec` version where the `slang_solidity` dependency does not support a given (probably newer) Solidity version. For example, the latest `slang_solidity` version does not support Solidity 0.8.29 at the time of writing. Projects which use that Solidity version but not any of the new syntax it adds could very well use the 0.8.28 version of the parser as an escape hatch until the new version is officially supported by `slang_solidity`.

### Breaking Changes

- The `lint:lint` function now takes a parser instance instead of a generic type.
- The `parser::Parse` trait's `parse_document` function now takes `&mut self` to enable configurable and/or stateful parsers.