### PR TITLE
refactor(definitions): create own text range type

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740019556,
-        "narHash": "sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g=",
+        "lastModified": 1744032190,
+        "narHash": "sha256-KSlfrncSkcu1YE+uuJ/PTURsSlThoGkRqiGDVdbiE/k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dad564433178067be1fbdfcce23b546254b6d641",
+        "rev": "b0b4b5f8f621bfe213b8b21694bab52ecfcbf30b",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740104932,
-        "narHash": "sha256-FaN+HBAhOW1wAjxPI/Ko1DX0ax4ucHCZoMJ0dGMxm8o=",
+        "lastModified": 1744166053,
+        "narHash": "sha256-mpI7OzFwp+fUeDtZYQbVZ2YmtxTN2UNrrOwbYD27xKU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c932b3873a5d56126bc1f1416fb8a58315f86c17",
+        "rev": "896158be1835589db6f42f45ef0a49b8b492cc66",
         "type": "github"
       },
       "original": {

--- a/src/definitions/constructor.rs
+++ b/src/definitions/constructor.rs
@@ -1,12 +1,10 @@
 //! Parsing and validation of constructors.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, ItemDiagnostics},
     natspec::NatSpec,
 };
 
-use super::{Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
 
 /// A constructor definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/enumeration.rs
+++ b/src/definitions/enumeration.rs
@@ -1,12 +1,10 @@
 //! Parsing and validation of enum definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, ItemDiagnostics},
     natspec::NatSpec,
 };
 
-use super::{Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
 
 /// An enum definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/error.rs
+++ b/src/definitions/error.rs
@@ -1,12 +1,10 @@
 //! Parsing and validation of error definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, ItemDiagnostics},
     natspec::NatSpec,
 };
 
-use super::{Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
 
 /// An error definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/event.rs
+++ b/src/definitions/event.rs
@@ -1,12 +1,10 @@
 //! Parsing and validation of event definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, ItemDiagnostics},
     natspec::NatSpec,
 };
 
-use super::{Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
 
 /// An event definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/function.rs
+++ b/src/definitions/function.rs
@@ -1,13 +1,12 @@
 //! Parsing and validation of function definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, check_returns, Diagnostic, ItemDiagnostics},
     natspec::{NatSpec, NatSpecKind},
 };
 
 use super::{
-    Attributes, Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions, Visibility,
+    Attributes, Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions,
+    Visibility,
 };
 
 /// A function definition

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! This module contains structs for each of the source item types that can be documented with `NatSpec`.
 //! The [`Definition`] type provides a unified interface to interact with the various types.
+use std::ops::Range;
+
 use constructor::ConstructorDefinition;
 use derive_more::{Display, From, IsVariant};
 use enumeration::EnumDefinition;
@@ -10,7 +12,7 @@ use event::EventDefinition;
 use function::FunctionDefinition;
 use modifier::ModifierDefinition;
 use serde::{Deserialize, Serialize};
-pub use slang_solidity::cst::TextRange;
+use slang_solidity::cst::TextIndex as SlangTextIndex;
 use structure::StructDefinition;
 use variable::VariableDeclaration;
 
@@ -40,6 +42,60 @@ pub trait SourceItem {
 
     /// Retrieve the span of the source item
     fn span(&self) -> TextRange;
+}
+
+pub type TextRange = Range<TextIndex>;
+
+#[derive(Default, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
+pub struct TextIndex {
+    pub utf8: usize,
+    pub utf16: usize,
+    pub line: usize,
+    pub column: usize,
+}
+
+impl TextIndex {
+    /// Shorthand for `TextIndex { utf8: 0, utf16: 0, line: 0, char: 0 }`.
+    pub const ZERO: TextIndex = TextIndex {
+        utf8: 0,
+        utf16: 0,
+        line: 0,
+        column: 0,
+    };
+}
+
+impl PartialOrd for TextIndex {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TextIndex {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.utf8.cmp(&other.utf8)
+    }
+}
+
+impl From<SlangTextIndex> for TextIndex {
+    fn from(value: SlangTextIndex) -> Self {
+        Self {
+            utf8: value.utf8,
+            utf16: value.utf16,
+            line: value.line,
+            column: value.column,
+        }
+    }
+}
+
+impl From<TextIndex> for SlangTextIndex {
+    fn from(value: TextIndex) -> Self {
+        Self {
+            utf8: value.utf8,
+            utf16: value.utf16,
+            line: value.line,
+            column: value.column,
+        }
+    }
 }
 
 /// An identifier (named or unnamed) and its span

--- a/src/definitions/mod.rs
+++ b/src/definitions/mod.rs
@@ -44,8 +44,12 @@ pub trait SourceItem {
     fn span(&self) -> TextRange;
 }
 
+/// A span of source code
 pub type TextRange = Range<TextIndex>;
 
+/// A position inside of the source code
+///
+/// Lines and columns start at 0.
 #[derive(Default, Hash, Copy, Clone, PartialEq, Eq, Debug, Serialize)]
 pub struct TextIndex {
     pub utf8: usize,

--- a/src/definitions/modifier.rs
+++ b/src/definitions/modifier.rs
@@ -1,12 +1,12 @@
 //! Parsing and validation of modifier definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, Diagnostic, ItemDiagnostics},
     natspec::{NatSpec, NatSpecKind},
 };
 
-use super::{Attributes, Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{
+    Attributes, Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions,
+};
 
 /// A modifier definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/structure.rs
+++ b/src/definitions/structure.rs
@@ -1,12 +1,10 @@
 //! Parsing and validation of struct definitions.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_params, ItemDiagnostics},
     natspec::NatSpec,
 };
 
-use super::{Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions};
+use super::{Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
 
 /// A struct definition
 #[derive(Debug, Clone, bon::Builder)]

--- a/src/definitions/variable.rs
+++ b/src/definitions/variable.rs
@@ -1,13 +1,12 @@
 //! Parsing and validation of state variable declarations.
-use slang_solidity::cst::TextRange;
-
 use crate::{
     lint::{check_notice_and_dev, check_returns, Diagnostic, ItemDiagnostics},
     natspec::{NatSpec, NatSpecKind},
 };
 
 use super::{
-    Attributes, Identifier, ItemType, Parent, SourceItem, Validate, ValidationOptions, Visibility,
+    Attributes, Identifier, ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions,
+    Visibility,
 };
 
 /// A state variable declaration

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,7 @@
 //! The error and result types for lintspec
 use std::path::PathBuf;
 
-use slang_solidity::cst::TextRange;
-
-use crate::definitions::Parent;
+use crate::definitions::{Parent, TextRange};
 
 /// The result of a lintspec operation
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -8,11 +8,10 @@ use std::{
 };
 
 use serde::Serialize;
-use slang_solidity::cst::TextRange;
 
 use crate::{
     config::{Config, FunctionConfig, Req, VariableConfig, WithParamsRules},
-    definitions::{Identifier, ItemType, Parent},
+    definitions::{Identifier, ItemType, Parent, TextRange},
     error::Result,
     natspec::NatSpec,
     parser::{Parse, ParsedDocument},

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 //! Utils for parsing Solidity source code.
-use std::sync::LazyLock;
+use std::{fmt::Write as _, sync::LazyLock};
 
 use regex::Regex;
 pub use semver;
@@ -102,7 +102,8 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
                 let v = version_reqs
                     .last_mut()
                     .expect("version expression should be inside an expression set");
-                v.push_str(&format!(",>={},<={}", start.trim(), end.trim()));
+                let _ = write!(v, ",>={},<={}", start.trim(), end.trim());
+                // v.push_str(&format!(",>={},<={}", start.trim(), end.trim()));
             } else {
                 let v = version_reqs
                     .last_mut()
@@ -110,9 +111,9 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
                 // for `semver`, the different specifiers should be combined with a comma if they must all match
                 if let Some(true) = text.chars().next().map(|c| c.is_ascii_digit()) {
                     // for `semver`, no comparator is the same as the caret comparator, but for solidity is means `=`
-                    v.push_str(&format!(",={text}"));
+                    let _ = write!(v, ",={text}");
                 } else {
-                    v.push_str(&format!(",{text}"));
+                    let _ = write!(v, ",{text}");
                 }
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -103,7 +103,6 @@ pub fn detect_solidity_version(src: &str) -> Result<Version> {
                     .last_mut()
                     .expect("version expression should be inside an expression set");
                 let _ = write!(v, ",>={},<={}", start.trim(), end.trim());
-                // v.push_str(&format!(",>={},<={}", start.trim(), end.trim()));
             } else {
                 let v = version_reqs
                     .last_mut()


### PR DESCRIPTION
This way, `slang_solidity` does not have to be a hard dependency of this crate later on.