### PR TITLE
refactor(parser)!: change input from path to reader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "lastModified": 1745377448,
+        "narHash": "sha256-jhZDfXVKdD7TSEGgzFJQvEEZ2K65UMiqW5YJ2aIqxMA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "rev": "507b63021ada5fee621b6ca371c4fca9ca46f52c",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745029910,
-        "narHash": "sha256-9CtbfTTQWMoOkXejxc5D+K3z/39wkQQt2YfYJW50tnI=",
+        "lastModified": 1745462120,
+        "narHash": "sha256-TbVjPOl+Cg5vZ7TIn1KpQ8SOfHKD6OEgu84b6YSCfKE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "50fefac8cdfd1587ac6d8678f6181e7d348201d2",
+        "rev": "79d3acd1a7e67fb9315fa5c5556eb6adf93dc2da",
         "type": "github"
       },
       "original": {

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -3,6 +3,7 @@
 //! The [`lint`] function parsers the source file and contained items, validates them according to the configured
 //! rules and emits a list of diagnostics, grouped by source item.
 use std::{
+    fs::File,
     io,
     path::{Path, PathBuf},
 };
@@ -12,7 +13,7 @@ use serde::Serialize;
 use crate::{
     config::{Config, FunctionConfig, Req, VariableConfig, WithParamsRules},
     definitions::{Identifier, ItemType, Parent, TextRange},
-    error::Result,
+    error::{Error, Result},
     natspec::NatSpec,
     parser::{Parse, ParsedDocument},
 };
@@ -139,7 +140,11 @@ pub fn lint(
             items,
         })
     }
-    let document = parser.parse_document(&path, keep_contents)?;
+    let file = File::open(&path).map_err(|err| Error::IOError {
+        path: path.as_ref().to_path_buf(),
+        err,
+    })?;
+    let document = parser.parse_document(file, keep_contents)?;
     Ok(inner(path.as_ref(), document, options))
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,7 +17,7 @@ pub struct ParsedDocument {
 
 /// The trait implemented by all parsers
 pub trait Parse {
-    /// Parse a document at `path` and identify the relevant source items
+    /// Parse a document from a reader and identify the relevant source items
     ///
     /// The fact that this takes in a mutable reference to the parser allows for stateful parsers.
     fn parse_document(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
 //! Solidity parser interface
-use std::path::Path;
+use std::io;
 
 use crate::{definitions::Definition, error::Result};
 
@@ -22,7 +22,7 @@ pub trait Parse {
     /// The fact that this takes in a mutable reference to the parser allows for stateful parsers.
     fn parse_document(
         &mut self,
-        path: impl AsRef<Path>,
+        input: impl io::Read,
         keep_contents: bool,
     ) -> Result<ParsedDocument>;
 }


### PR DESCRIPTION
This PR changes the signature of the `Parse::parse_document` function so that it accepts a `impl io::Read` reader. This makes the API more versatile and allows to read from streams, stdin, etc.

### Breaking Change

- `Parse::parse_document ` now takes an `impl io::Read` instead of an `impl AsRef<Path>`.

Closes #73