### PR TITLE
fix(slang): ignore non-doc-comments in span

### DIFF
--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -690,10 +690,12 @@ pub fn extract_struct_members(cursor: &Cursor) -> Result<Vec<Identifier>> {
 pub fn find_definition_start(cursor: &Cursor) -> Option<TextRange> {
     let mut cursor = cursor.spawn();
     while cursor.go_to_next() {
-        if cursor
-            .node()
-            .is_terminal_with_kinds(&[TerminalKind::Whitespace, TerminalKind::EndOfLine])
-        {
+        if cursor.node().is_terminal_with_kinds(&[
+            TerminalKind::Whitespace,
+            TerminalKind::EndOfLine,
+            TerminalKind::SingleLineComment,
+            TerminalKind::MultiLineComment,
+        ]) {
             continue;
         }
         // special case for state variables, since the doc-comment is inside of the type node for some reason

--- a/tests/snapshots/tests_parser_test__basic.snap
+++ b/tests/snapshots/tests_parser_test__basic.snap
@@ -16,7 +16,7 @@ event IParserTest.SimpleEvent
 function IParserTest.SOME_CONSTANT
   @return _returned is missing
 
-./test-data/ParserTest.sol:120:3
+./test-data/ParserTest.sol:121:3
 struct ParserTestFunny.SimpleStruct
   @notice is missing
 
@@ -24,24 +24,24 @@ struct ParserTestFunny.SimpleStruct
 modifier ParserTestFunny.someModifier
   @notice is missing
 
-./test-data/ParserTest.sol:136:3
+./test-data/ParserTest.sol:137:3
 variable ParserTestFunny.SOME_CONSTANT
   @notice is missing
   @return is missing
 
-./test-data/ParserTest.sol:144:3
+./test-data/ParserTest.sol:145:3
 function ParserTestFunny.viewFunctionWithParams
   @notice is missing
   @param _param1 is missing
   @param _param2 is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:149:3
+./test-data/ParserTest.sol:150:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:181:3
+./test-data/ParserTest.sol:182:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @param _paramName is missing

--- a/tests/snapshots/tests_parser_test__constructor.snap
+++ b/tests/snapshots/tests_parser_test__constructor.snap
@@ -16,7 +16,7 @@ event IParserTest.SimpleEvent
 function IParserTest.SOME_CONSTANT
   @return _returned is missing
 
-./test-data/ParserTest.sol:120:3
+./test-data/ParserTest.sol:121:3
 struct ParserTestFunny.SimpleStruct
   @notice is missing
 
@@ -24,24 +24,24 @@ struct ParserTestFunny.SimpleStruct
 modifier ParserTestFunny.someModifier
   @notice is missing
 
-./test-data/ParserTest.sol:136:3
+./test-data/ParserTest.sol:137:3
 variable ParserTestFunny.SOME_CONSTANT
   @notice is missing
   @return is missing
 
-./test-data/ParserTest.sol:144:3
+./test-data/ParserTest.sol:145:3
 function ParserTestFunny.viewFunctionWithParams
   @notice is missing
   @param _param1 is missing
   @param _param2 is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:149:3
+./test-data/ParserTest.sol:150:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:181:3
+./test-data/ParserTest.sol:182:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @param _paramName is missing

--- a/tests/snapshots/tests_parser_test__enum.snap
+++ b/tests/snapshots/tests_parser_test__enum.snap
@@ -22,7 +22,7 @@ enum IParserTest.SimpleEnum
 function IParserTest.SOME_CONSTANT
   @return _returned is missing
 
-./test-data/ParserTest.sol:120:3
+./test-data/ParserTest.sol:121:3
 struct ParserTestFunny.SimpleStruct
   @notice is missing
 
@@ -30,24 +30,24 @@ struct ParserTestFunny.SimpleStruct
 modifier ParserTestFunny.someModifier
   @notice is missing
 
-./test-data/ParserTest.sol:136:3
+./test-data/ParserTest.sol:137:3
 variable ParserTestFunny.SOME_CONSTANT
   @notice is missing
   @return is missing
 
-./test-data/ParserTest.sol:144:3
+./test-data/ParserTest.sol:145:3
 function ParserTestFunny.viewFunctionWithParams
   @notice is missing
   @param _param1 is missing
   @param _param2 is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:149:3
+./test-data/ParserTest.sol:150:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:181:3
+./test-data/ParserTest.sol:182:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @param _paramName is missing

--- a/tests/snapshots/tests_parser_test__inheritdoc.snap
+++ b/tests/snapshots/tests_parser_test__inheritdoc.snap
@@ -16,7 +16,7 @@ event IParserTest.SimpleEvent
 function IParserTest.SOME_CONSTANT
   @return _returned is missing
 
-./test-data/ParserTest.sol:120:3
+./test-data/ParserTest.sol:121:3
 struct ParserTestFunny.SimpleStruct
   @notice is missing
 
@@ -24,20 +24,20 @@ struct ParserTestFunny.SimpleStruct
 modifier ParserTestFunny.someModifier
   @notice is missing
 
-./test-data/ParserTest.sol:136:3
+./test-data/ParserTest.sol:137:3
 variable ParserTestFunny.SOME_CONSTANT
   @inheritdoc is missing
 
-./test-data/ParserTest.sol:144:3
+./test-data/ParserTest.sol:145:3
 function ParserTestFunny.viewFunctionWithParams
   @inheritdoc is missing
 
-./test-data/ParserTest.sol:149:3
+./test-data/ParserTest.sol:150:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:181:3
+./test-data/ParserTest.sol:182:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @param _paramName is missing

--- a/tests/snapshots/tests_parser_test__struct.snap
+++ b/tests/snapshots/tests_parser_test__struct.snap
@@ -16,7 +16,7 @@ event IParserTest.SimpleEvent
 function IParserTest.SOME_CONSTANT
   @return _returned is missing
 
-./test-data/ParserTest.sol:120:3
+./test-data/ParserTest.sol:121:3
 struct ParserTestFunny.SimpleStruct
   @notice is missing
   @param a is missing
@@ -26,24 +26,24 @@ struct ParserTestFunny.SimpleStruct
 modifier ParserTestFunny.someModifier
   @notice is missing
 
-./test-data/ParserTest.sol:136:3
+./test-data/ParserTest.sol:137:3
 variable ParserTestFunny.SOME_CONSTANT
   @notice is missing
   @return is missing
 
-./test-data/ParserTest.sol:144:3
+./test-data/ParserTest.sol:145:3
 function ParserTestFunny.viewFunctionWithParams
   @notice is missing
   @param _param1 is missing
   @param _param2 is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:149:3
+./test-data/ParserTest.sol:150:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:181:3
+./test-data/ParserTest.sol:182:3
 function ParserTestFunny._viewInternal
   @notice is missing
   @param _paramName is missing


### PR DESCRIPTION
Fixing an edge case where the location of the `TextRange` for an item (in compact mode) would start at a normal (non-natspec) comment.