### PR TITLE
fix(slang): ignore natspec comments which start with too many slashes or stars

### DIFF
--- a/test-data/ParserTest.sol
+++ b/test-data/ParserTest.sol
@@ -196,6 +196,9 @@ contract ParserTestFunny is IParserTest {
 
   }
 
+  ///////////
+  //  hello //
+  ///////////
   /// fun fact: there are extra spaces after the 1st return
   /// @return       
   /// @return

--- a/tests/snapshots/tests_parser_test__basic.snap
+++ b/tests/snapshots/tests_parser_test__basic.snap
@@ -41,18 +41,12 @@ function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:182:3
-ParsingError 
-  //// @dev Too many slashes is also not a valid comment
-   ^
-invalid delimiter
-expected ///
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
 
-./test-data/ParserTest.sol:187:4
-ParsingError 
-  parse error at line 1, column 4
-  |
-1 | /***
-  |    ^
-invalid delimiter
-expected /**
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing

--- a/tests/snapshots/tests_parser_test__constructor.snap
+++ b/tests/snapshots/tests_parser_test__constructor.snap
@@ -41,18 +41,12 @@ function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:182:3
-ParsingError 
-  //// @dev Too many slashes is also not a valid comment
-   ^
-invalid delimiter
-expected ///
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
 
-./test-data/ParserTest.sol:187:4
-ParsingError 
-  parse error at line 1, column 4
-  |
-1 | /***
-  |    ^
-invalid delimiter
-expected /**
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing

--- a/tests/snapshots/tests_parser_test__enum.snap
+++ b/tests/snapshots/tests_parser_test__enum.snap
@@ -47,18 +47,12 @@ function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:182:3
-ParsingError 
-  //// @dev Too many slashes is also not a valid comment
-   ^
-invalid delimiter
-expected ///
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
 
-./test-data/ParserTest.sol:187:4
-ParsingError 
-  parse error at line 1, column 4
-  |
-1 | /***
-  |    ^
-invalid delimiter
-expected /**
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing

--- a/tests/snapshots/tests_parser_test__inheritdoc.snap
+++ b/tests/snapshots/tests_parser_test__inheritdoc.snap
@@ -37,22 +37,16 @@ function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:182:3
-ParsingError 
-  //// @dev Too many slashes is also not a valid comment
-   ^
-invalid delimiter
-expected ///
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
 
-./test-data/ParserTest.sol:187:4
-ParsingError 
-  parse error at line 1, column 4
-  |
-1 | /***
-  |    ^
-invalid delimiter
-expected /**
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing
 
-./test-data/ParserTest.sol:199:3
+./test-data/ParserTest.sol:202:3
 function ParserTestFunny.functionUnnamedEmptyReturn
   @inheritdoc is missing

--- a/tests/snapshots/tests_parser_test__struct.snap
+++ b/tests/snapshots/tests_parser_test__struct.snap
@@ -43,18 +43,12 @@ function ParserTestFunny._viewInternal
   @notice is missing
   @return missing for unnamed return #1
 
-./test-data/ParserTest.sol:182:3
-ParsingError 
-  //// @dev Too many slashes is also not a valid comment
-   ^
-invalid delimiter
-expected ///
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
 
-./test-data/ParserTest.sol:187:4
-ParsingError 
-  parse error at line 1, column 4
-  |
-1 | /***
-  |    ^
-invalid delimiter
-expected /**
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing


### PR DESCRIPTION
https://github.com/beeb/lintspec/pull/77 made the parser throw an error if it encounters NatSpec comments starting with `////` or `/***`, which is fine, but this error should not propagate to the end user.

These comments are now considered as normal comments and not NatSpec comments, so they get skipped completely when checking NatSpec, which is in line with what solc does.