### PR TITLE
feat(lint): orphan params generate diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "figment",
  "ignore",
  "insta",
+ "itertools 0.14.0",
  "miette",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ dotenvy = "0.15.7"
 dunce = "1.0.5"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 ignore = "0.4.23"
+itertools = "0.14.0"
 miette = { version = "7.5.0", features = ["fancy"] }
 rayon = "1.10.0"
 regex = "1.11.1"

--- a/src/definitions/structure.rs
+++ b/src/definitions/structure.rs
@@ -280,7 +280,22 @@ mod tests {
                 uint256 foo;
             }";
         let res = parse_file(contents).validate(&OPTIONS);
+        assert_eq!(res.diags.len(), 2);
+        assert_eq!(res.diags[0].message, "extra @param fooThe");
+        assert_eq!(res.diags[1].message, "@param foo is missing");
+    }
+
+    #[test]
+    fn test_struct_extra_param() {
+        let contents = "
+            /// @notice A struct
+            /// @param foo The param
+            /// @param bar Some other param
+            struct Test {
+                uint256 foo;
+            }";
+        let res = parse_file(contents).validate(&OPTIONS);
         assert_eq!(res.diags.len(), 1);
-        assert_eq!(res.diags[0].message, "@param foo is missing");
+        assert_eq!(res.diags[0].message, "extra @param bar");
     }
 }


### PR DESCRIPTION
Although the solidity compiler generates warning for "ophan" `@param` natspec entries in function-like items, it doesn't do it for structs and enums (because it's not part of the spec, at least yet). 
Lintspec will now report extraneous `@param` entries for all items.