### PR TITLE
feat(parser)!: parsers own the source buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "solar-parse",
  "thiserror 2.0.16",
  "toml 0.9.5",
+ "uuid",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ slang_solidity = { version = "0.18.3", optional = true }
 solar-parse = { version = "0.1.4", default-features = false, optional = true }
 thiserror = "2.0.11"
 toml = "0.9.2"
+uuid = { version = "1.18.1", features = ["v4"] }
 winnow = "0.7.2"
 
 [dev-dependencies]

--- a/benches/lint.rs
+++ b/benches/lint.rs
@@ -58,7 +58,7 @@ fn lint_e2e(bencher: Bencher, path: &str) {
 #[cfg(feature = "solar")]
 #[divan::bench(args = FILES)]
 fn lint_e2e_solar(bencher: Bencher, path: &str) {
-    let parser = lintspec::parser::solar::SolarParser {};
+    let parser = lintspec::parser::solar::SolarParser::default();
     let options = ValidationOptions::default();
     bencher.bench_local(move || {
         black_box(lint(parser.clone(), path, &options, false).ok());

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -34,6 +34,6 @@ fn parse_slang(bencher: Bencher, path: &str) {
 #[cfg(feature = "solar")]
 #[divan::bench(args = FILES)]
 fn parse_solar(bencher: Bencher, path: &str) {
-    let parser = lintspec::parser::solar::SolarParser {};
+    let parser = lintspec::parser::solar::SolarParser::default();
     bencher.bench_local(move || black_box(parse_file(parser.clone(), path)));
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,11 @@ pub enum Error {
         message: String,
     },
 
+    /// [`Parse::get_sources`][crate::parser::Parse::get_sources] was called while other references (clones) still
+    /// existed
+    #[error("`Parse::get_sources` can only be called on the last parser instance")]
+    DanglingParserReferences,
+
     /// IO error
     #[error("IO error for {path:?}: {err}")]
     IOError { path: PathBuf, err: std::io::Error },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub fn print_reports(
     f: &mut impl io::Write,
     root_path: impl AsRef<Path>,
     file_diags: FileDiagnostics,
+    contents: String,
     compact: bool,
 ) -> std::result::Result<(), io::Error> {
     if compact {
@@ -38,10 +39,7 @@ pub fn print_reports(
             Ok(relative_path) => relative_path.to_string_lossy(),
             Err(_) => file_diags.path.to_string_lossy(),
         };
-        let source = Arc::new(NamedSource::new(
-            source_name,
-            file_diags.contents.unwrap_or_default(),
-        ));
+        let source = Arc::new(NamedSource::new(source_name, contents));
         for item_diags in file_diags.items {
             print_report(f, Arc::clone(&source), item_diags)?;
         }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -17,7 +17,7 @@ use crate::{
     definitions::{Identifier, ItemType, Parent, TextRange},
     error::{Error, Result},
     natspec::{NatSpec, NatSpecKind},
-    parser::{Parse, ParsedDocument},
+    parser::{DocumentId, Parse, ParsedDocument},
 };
 
 /// Diagnostics for a single Solidity file
@@ -27,9 +27,12 @@ pub struct FileDiagnostics {
     /// Path to the file
     pub path: PathBuf,
 
-    /// Contents of the file (can be an empty string if pretty output is not activated)
+    /// A unique ID for the document given by the parser
+    ///
+    /// Can be used to retrieve the document contents after parsing (via
+    /// [`Parse::get_contents`][crate::parser::Parse::get_contents]).
     #[serde(skip_serializing)]
-    pub contents: Option<String>,
+    pub document_id: DocumentId,
 
     /// Diagnostics, grouped by source item (function, struct, etc.)
     pub items: Vec<ItemDiagnostics>,
@@ -133,7 +136,7 @@ pub fn lint(
         items.sort_unstable_by_key(|i| i.span.start);
         Some(FileDiagnostics {
             path: path.to_path_buf(),
-            contents: document.contents,
+            document_id: document.id,
             items,
         })
     }

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -29,8 +29,7 @@ pub struct FileDiagnostics {
 
     /// A unique ID for the document given by the parser
     ///
-    /// Can be used to retrieve the document contents after parsing (via
-    /// [`Parse::get_contents`][crate::parser::Parse::get_contents]).
+    /// Can be used to retrieve the document contents after parsing (via [`Parse::get_sources`]).
     #[serde(skip_serializing)]
     pub document_id: DocumentId,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,8 @@ fn main() -> Result<()> {
     } else {
         let cwd = dunce::canonicalize(env::current_dir()?)?;
         let mut contents = if cfg!(any(feature = "slang", feature = "solar")) {
-            parser.get_sources()
+            // all other clones have been dropped
+            parser.get_sources()?
         } else {
             HashMap::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
         .build();
 
     #[cfg(feature = "solar")]
-    let parser = SolarParser {};
+    let parser = SolarParser::default();
 
     let diagnostics = paths
         .par_iter()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ impl DocumentId {
 pub struct ParsedDocument {
     /// A unique ID for the document given by the parser
     ///
-    /// Can be used to retrieve the document contents after parsing (via [`Parse::get_contents`]).
+    /// Can be used to retrieve the document contents after parsing (via [`Parse::get_sources`]).
     pub id: DocumentId,
 
     /// The list of definitions found in the document

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,7 +37,8 @@ pub struct ParsedDocument {
 /// The trait implemented by all parsers
 ///
 /// Ideally, cloning a parser should not duplicate the contents of the sources. The underlying data should be wrapped
-/// in an [`Arc`], so that the last clone of a parser is able to retrieve the sources' contents for all files.
+/// in an [`Arc`][std::sync::Arc], so that the last clone of a parser is able to retrieve the sources' contents for
+/// all files.
 pub trait Parse: Clone {
     /// Parse a document from a reader and identify the relevant source items
     ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -35,7 +35,10 @@ pub struct ParsedDocument {
 }
 
 /// The trait implemented by all parsers
-pub trait Parse {
+///
+/// Ideally, cloning a parser should not duplicate the contents of the sources. The underlying data should be wrapped
+/// in an [`Arc`], so that the last clone of a parser is able to retrieve the sources' contents for all files.
+pub trait Parse: Clone {
     /// Parse a document from a reader and identify the relevant source items
     ///
     /// If a path is provided, then this can be used to enrich diagnostics.
@@ -51,5 +54,7 @@ pub trait Parse {
     ///
     /// This consumes the parser, so that ownership of the contents can be retrieved safely.
     /// Note that documents which were parsed with `keep_contents` to `false` will no be present in the map.
-    fn get_sources(self) -> HashMap<DocumentId, String>;
+    ///
+    /// This can return an error if there are more than one clone of the parser.
+    fn get_sources(self) -> Result<HashMap<DocumentId, String>>;
 }

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -147,11 +147,11 @@ impl Parse for SlangParser {
         })
     }
 
-    fn get_sources(self) -> HashMap<DocumentId, String> {
-        Arc::try_unwrap(self.documents)
-            .expect("all references should have been dropped")
+    fn get_sources(self) -> Result<HashMap<DocumentId, String>> {
+        Ok(Arc::try_unwrap(self.documents)
+            .map_err(|_| Error::DanglingParserReferences)?
             .into_inner()
-            .expect("mutex should not be poisoned")
+            .expect("mutex should not be poisoned"))
     }
 }
 

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -130,9 +130,10 @@ impl Parse for SolarParser {
         })
     }
 
-    fn get_sources(self) -> HashMap<DocumentId, String> {
-        drop(self.sess);
-        Arc::try_unwrap(self.documents)
+    fn get_sources(self) -> Result<HashMap<DocumentId, String>> {
+        let sess = Arc::try_unwrap(self.sess).map_err(|_| Error::DanglingParserReferences)?;
+        drop(sess);
+        Ok(Arc::try_unwrap(self.documents)
             .expect("all references should have been dropped")
             .into_inner()
             .expect("mutex should not be poisoned")
@@ -146,7 +147,7 @@ impl Parse for SolarParser {
                         .expect("all SourceFile references should have been dropped"),
                 )
             })
-            .collect()
+            .collect())
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,7 +12,7 @@ use lintspec::{
 pub fn snapshot_content(path: &str, options: &ValidationOptions, keep_contents: bool) -> String {
     let parser = SlangParser::default();
     let diags_slang = lint(parser.clone(), path, options, keep_contents).unwrap();
-    let mut sources = parser.get_sources();
+    let mut sources = parser.get_sources().unwrap();
     let contents = diags_slang
         .as_ref()
         .and_then(|f| sources.remove(&f.document_id));
@@ -21,7 +21,7 @@ pub fn snapshot_content(path: &str, options: &ValidationOptions, keep_contents: 
     {
         let parser = lintspec::parser::solar::SolarParser::default();
         let diags_solar = lint(parser.clone(), path, options, keep_contents).unwrap();
-        let mut sources = parser.get_sources();
+        let mut sources = parser.get_sources().unwrap();
         let contents = diags_solar
             .as_ref()
             .and_then(|f| sources.remove(&f.document_id));

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,34 +3,44 @@ use std::path::PathBuf;
 
 use lintspec::{
     lint::{ValidationOptions, lint},
-    parser::slang::SlangParser,
+    parser::{Parse as _, slang::SlangParser},
     print_reports,
 };
 
 #[allow(unused_variables)]
 #[must_use]
 pub fn snapshot_content(path: &str, options: &ValidationOptions, keep_contents: bool) -> String {
-    let diags_slang = lint(SlangParser::builder().build(), path, options, keep_contents).unwrap();
-    let output = generate_output(diags_slang);
+    let parser = SlangParser::default();
+    let diags_slang = lint(parser.clone(), path, options, keep_contents).unwrap();
+    let mut sources = parser.get_sources();
+    let contents = diags_slang
+        .as_ref()
+        .and_then(|f| sources.remove(&f.document_id));
+    let output = generate_output(diags_slang, contents);
     #[cfg(feature = "solar")]
     {
-        let diags_solar = lint(
-            lintspec::parser::solar::SolarParser::default(),
-            path,
-            options,
-            keep_contents,
-        )
-        .unwrap();
-        similar_asserts::assert_eq!(output, generate_output(diags_solar));
+        let parser = lintspec::parser::solar::SolarParser::default();
+        let diags_solar = lint(parser.clone(), path, options, keep_contents).unwrap();
+        let mut sources = parser.get_sources();
+        let contents = diags_solar
+            .as_ref()
+            .and_then(|f| sources.remove(&f.document_id));
+        similar_asserts::assert_eq!(output, generate_output(diags_solar, contents));
     }
     output
 }
 
-fn generate_output(diags: Option<lintspec::lint::FileDiagnostics>) -> String {
+fn generate_output(
+    diags: Option<lintspec::lint::FileDiagnostics>,
+    contents: Option<String>,
+) -> String {
     let Some(diags) = diags else {
         return String::new();
     };
     let mut buf = Vec::new();
-    print_reports(&mut buf, PathBuf::new(), diags, true).unwrap();
+    let Some(contents) = contents else {
+        return String::new();
+    };
+    print_reports(&mut buf, PathBuf::new(), diags, contents, true).unwrap();
     String::from_utf8(buf).unwrap()
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -15,7 +15,7 @@ pub fn snapshot_content(path: &str, options: &ValidationOptions, keep_contents: 
     #[cfg(feature = "solar")]
     {
         let diags_solar = lint(
-            lintspec::parser::solar::SolarParser {},
+            lintspec::parser::solar::SolarParser::default(),
             path,
             options,
             keep_contents,

--- a/tests/tests-solar.rs
+++ b/tests/tests-solar.rs
@@ -16,7 +16,7 @@ fn test_basic() {
     .unwrap()
     .unwrap();
     let diags_solar = lint(
-        SolarParser {},
+        SolarParser::default(),
         "./test-data/BasicSample.sol",
         &ValidationOptions::default(),
         false,
@@ -37,7 +37,7 @@ fn test_fuzzers() {
     .unwrap()
     .unwrap();
     let diags_solar = lint(
-        SolarParser {},
+        SolarParser::default(),
         "./test-data/Fuzzers.sol",
         &ValidationOptions::default(),
         false,
@@ -58,7 +58,7 @@ fn test_interface() {
     .unwrap()
     .unwrap();
     let diags_solar = lint(
-        SolarParser {},
+        SolarParser::default(),
         "./test-data/InterfaceSample.sol",
         &ValidationOptions::default(),
         false,
@@ -79,7 +79,7 @@ fn test_library() {
     .unwrap()
     .unwrap();
     let diags_solar = lint(
-        SolarParser {},
+        SolarParser::default(),
         "./test-data/LibrarySample.sol",
         &ValidationOptions::default(),
         false,
@@ -100,7 +100,7 @@ fn test_parsertest() {
     .unwrap()
     .unwrap();
     let diags_solar = lint(
-        SolarParser {},
+        SolarParser::default(),
         "./test-data/ParserTest.sol",
         &ValidationOptions::default(),
         false,

--- a/tests/tests-solar.rs
+++ b/tests/tests-solar.rs
@@ -23,7 +23,7 @@ fn test_basic() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(slang: format!("{diags_slang:#?}"), solar: format!("{diags_solar:#?}"));
+    assert_eq!(slang: serde_json::to_string_pretty(&diags_slang).unwrap(), solar: serde_json::to_string_pretty(&diags_solar).unwrap());
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn test_fuzzers() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(slang: format!("{diags_slang:#?}"), solar: format!("{diags_solar:#?}"));
+    assert_eq!(slang: serde_json::to_string_pretty(&diags_slang).unwrap(), solar: serde_json::to_string_pretty(&diags_solar).unwrap());
 }
 
 #[test]
@@ -65,7 +65,7 @@ fn test_interface() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(slang: format!("{diags_slang:#?}"), solar: format!("{diags_solar:#?}"));
+    assert_eq!(slang: serde_json::to_string_pretty(&diags_slang).unwrap(), solar: serde_json::to_string_pretty(&diags_solar).unwrap());
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn test_library() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(slang: format!("{diags_slang:#?}"), solar: format!("{diags_solar:#?}"));
+    assert_eq!(slang: serde_json::to_string_pretty(&diags_slang).unwrap(), solar: serde_json::to_string_pretty(&diags_solar).unwrap());
 }
 
 #[test]
@@ -107,5 +107,5 @@ fn test_parsertest() {
     )
     .unwrap()
     .unwrap();
-    assert_eq!(slang: format!("{diags_slang:#?}"), solar: format!("{diags_solar:#?}"));
+    assert_eq!(slang: serde_json::to_string_pretty(&diags_slang).unwrap(), solar: serde_json::to_string_pretty(&diags_solar).unwrap());
 }


### PR DESCRIPTION
This PR changes the behavior of parsers to be stateful and keep references to the source code buffers until the end of parsing. The client can then retrieve the sources' contents while destroying the last parser instance with `Parse::get_sources`.

This allows to make the `SolarParser` stateful and re-use the same session, while avoiding to clone the source buffers for pretty diagnostics. Performance is improved.

Closes https://github.com/beeb/lintspec/issues/126