### PR TITLE
feat!: add `inheritdoc_override` param for internal functions and modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options:
       --config <CONFIG>          Optional path to a TOML config file
   -o, --out <OUT>                Write output to a file instead of stderr
       --inheritdoc               Enforce that all public and external items have `@inheritdoc`
+      --inheritdoc-override      Enforce that `override` internal functions and modifiers have `@inheritdoc`
       --notice-or-dev            Do not distinguish between `@notice` and `@dev` when considering "required" validation rules
       --skip-version-detection   Skip the detection of the Solidity version from pragma statements
       --notice-ignored <TYPE>    Ignore `@notice` for these items (can be used more than once)

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,7 @@ impl WithParamsRules {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 #[skip_serializing_none]
 #[non_exhaustive]
+#[allow(clippy::struct_excessive_bools)]
 pub struct BaseConfig {
     /// Paths to files and folders to analyze
     #[builder(default)]
@@ -283,6 +284,10 @@ pub struct BaseConfig {
     /// Enforce that all public and external items have `@inheritdoc`
     #[builder(default = true)]
     pub inheritdoc: bool,
+
+    /// Enforce that internal functions and modifiers which are `override` have `@inheritdoc`
+    #[builder(default = false)]
+    pub inheritdoc_override: bool,
 
     /// Do not distinguish between `@notice` and `@dev` when considering "required" validation rules
     #[builder(default)]
@@ -299,6 +304,7 @@ impl Default for BaseConfig {
             paths: Vec::default(),
             exclude: Vec::default(),
             inheritdoc: true,
+            inheritdoc_override: false,
             notice_or_dev: false,
             skip_version_detection: false,
         }
@@ -464,11 +470,16 @@ pub struct Args {
 
     /// Enforce that all public and external items have `@inheritdoc`
     ///
-    /// Functions which override a parent function also must have `@inheritdoc`.
-    ///
     /// Can be set with `--inheritdoc` (means true), `--inheritdoc=true` or `--inheritdoc=false`.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub inheritdoc: Option<bool>,
+
+    /// Enforce that internal functions and modifiers which override a parent have `@inheritdoc`
+    ///
+    /// Can be set with `--inheritdoc-override` (means true), `--inheritdoc-override=true` or
+    /// `--inheritdoc-override=false`.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub inheritdoc_override: Option<bool>,
 
     /// Do not distinguish between `@notice` and `@dev` when considering "required" validation rules.
     ///
@@ -614,6 +625,9 @@ pub fn read_config(args: Args) -> Result<Config> {
     // natspec config
     if let Some(inheritdoc) = args.inheritdoc {
         config.lintspec.inheritdoc = inheritdoc;
+    }
+    if let Some(inheritdoc_override) = args.inheritdoc_override {
+        config.lintspec.inheritdoc_override = inheritdoc_override;
     }
     if let Some(notice_or_dev) = args.notice_or_dev {
         config.lintspec.notice_or_dev = notice_or_dev;

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -149,9 +149,13 @@ pub fn lint(
 #[derive(Debug, Clone, PartialEq, Eq, bon::Builder)]
 #[non_exhaustive]
 pub struct ValidationOptions {
-    /// Whether overridden, public and external functions should have an `@inheritdoc`
+    /// Whether public and external functions should have an `@inheritdoc`
     #[builder(default = true)]
     pub inheritdoc: bool,
+
+    /// Whether `override` internal functions and modifiers should have an `@inheritdoc`
+    #[builder(default = false)]
+    pub inheritdoc_override: bool,
 
     /// Whether to enforce either `@notice` or `@dev` if either or both are required
     #[builder(default)]
@@ -198,6 +202,7 @@ impl Default for ValidationOptions {
     fn default() -> Self {
         Self {
             inheritdoc: true,
+            inheritdoc_override: false,
             notice_or_dev: false,
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
@@ -216,6 +221,7 @@ impl From<Config> for ValidationOptions {
     fn from(value: Config) -> Self {
         Self {
             inheritdoc: value.lintspec.inheritdoc,
+            inheritdoc_override: value.lintspec.inheritdoc_override,
             notice_or_dev: value.lintspec.notice_or_dev,
             constructors: value.constructors,
             enums: value.enums,
@@ -234,6 +240,7 @@ impl From<&Config> for ValidationOptions {
     fn from(value: &Config) -> Self {
         Self {
             inheritdoc: value.lintspec.inheritdoc,
+            inheritdoc_override: value.lintspec.inheritdoc_override,
             notice_or_dev: value.lintspec.notice_or_dev,
             constructors: value.constructors.clone(),
             enums: value.enums.clone(),

--- a/test-data/BasicSample.sol
+++ b/test-data/BasicSample.sol
@@ -111,7 +111,7 @@ contract BasicSample is AbstractBasic {
     /**
      * @notice Modifier notice
      */
-    modifier transferFee(uint256 _receiver) {
+    modifier transferFee(uint256 _receiver) virtual {
         _;
     }
 
@@ -124,4 +124,14 @@ contract BasicSample is AbstractBasic {
      * @dev This func must be ignored
      */
     fallback() external {}
+}
+
+contract ChildContract is BasicSample {
+    constructor() BasicSample(true) {}
+
+    /// @dev inheritdoc is missing
+    /// @param _receiver the receiver
+    modifier transferFee(uint256 _receiver) override {
+        _;
+    }
 }

--- a/tests/snapshots/tests_basic_sample__all.snap
+++ b/tests/snapshots/tests_basic_sample__all.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc_override(true).constructors(WithParamsRules::required()).enums(WithParamsRules::required()).modifiers(WithParamsRules::required()).structs(WithParamsRules::required()).variables(VariableConfig::builder().private(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).internal(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).build(),).build(),\ntrue,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -65,3 +65,11 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:130:5
+constructor ChildContract.constructor
+  @notice is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @inheritdoc is missing

--- a/tests/snapshots/tests_basic_sample__all_no_inheritdoc.snap
+++ b/tests/snapshots/tests_basic_sample__all_no_inheritdoc.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).constructors(WithParamsRules::required()).enums(WithParamsRules::required()).modifiers(WithParamsRules::required()).structs(WithParamsRules::required()).variables(VariableConfig::builder().private(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).internal(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).build(),).build(),\ntrue,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -54,3 +54,11 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:130:5
+constructor ChildContract.constructor
+  @notice is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/snapshots/tests_basic_sample__basic.snap
+++ b/tests/snapshots/tests_basic_sample__basic.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).build(), true,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -43,3 +43,7 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/snapshots/tests_basic_sample__constructor.snap
+++ b/tests/snapshots/tests_basic_sample__constructor.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).constructors(WithParamsRules::required()).build(),\ntrue,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -44,3 +44,11 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:130:5
+constructor ChildContract.constructor
+  @notice is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/snapshots/tests_basic_sample__enum.snap
+++ b/tests/snapshots/tests_basic_sample__enum.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).enums(WithParamsRules::required()).build(),\ntrue,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -48,3 +48,7 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/snapshots/tests_basic_sample__inheritdoc.snap
+++ b/tests/snapshots/tests_basic_sample__inheritdoc.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc_override(true).build(), true,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -54,3 +54,7 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @inheritdoc is missing

--- a/tests/snapshots/tests_basic_sample__struct.snap
+++ b/tests/snapshots/tests_basic_sample__struct.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: generate_output(diags)
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).structs(WithParamsRules::required()).build(),\ntrue,)"
 ---
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
@@ -48,3 +48,7 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -20,7 +20,9 @@ fn test_basic() {
 fn test_inheritdoc() {
     insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
-        &ValidationOptions::default(),
+        &ValidationOptions::builder()
+            .inheritdoc_override(true)
+            .build(),
         true,
     ));
 }
@@ -66,6 +68,7 @@ fn test_all() {
     insta::assert_snapshot!(snapshot_content(
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
+            .inheritdoc_override(true)
             .constructors(WithParamsRules::required())
             .enums(WithParamsRules::required())
             .modifiers(WithParamsRules::required())
@@ -97,6 +100,7 @@ fn test_all_no_inheritdoc() {
         "./test-data/BasicSample.sol",
         &ValidationOptions::builder()
             .inheritdoc(false)
+            .inheritdoc_override(false)
             .constructors(WithParamsRules::required())
             .enums(WithParamsRules::required())
             .modifiers(WithParamsRules::required())


### PR DESCRIPTION
Because the default value for this item is `false`, this changes the behavior compared to previous versions (because it used the `inheritdoc` flag which defaults to `true`) and is a breaking change.

To restore the v0.7 behavior, set `inheritdoc_override = true` in the config file under the `[lintspec]` section.

Closes https://github.com/beeb/lintspec/issues/123