### PR TITLE
refactor(slang): remove private field from builder

### DIFF
--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -36,7 +36,7 @@ pub struct SlangParser {
     #[builder(default)]
     pub skip_version_detection: bool,
 
-    #[builder(default)]
+    #[builder(skip)]
     documents: Arc<Mutex<HashMap<DocumentId, String>>>,
 }
 


### PR DESCRIPTION
Forgot to hide the private field from the builder