### PR TITLE
perf(parser): use lock-free vec for documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "bon",
+ "boxcar",
  "clap",
  "clap_complete",
  "codspeed-divan-compat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 anyhow = { version = "1.0.95", optional = true }
 bon = "3.3.2"
+boxcar = "0.2.14"
 clap = { version = "4.5.29", features = ["derive"], optional = true }
 clap_complete = { version = "4.5.57", optional = true }
 derive_more = { version = "2.0.1", features = [


### PR DESCRIPTION
Minimal gains (approx. 2% end-to-end on a real codebase when using `solar`) but could become more important with many small files.