### PR TITLE
ci(release-plz): action can now generate token on the fly

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - name: Generate crates.io token
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
@@ -37,7 +34,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
The token is generated by release-plz, no need for another action anymore.