### PR TITLE
feat!: add support for contracts, interfaces, and libraries

### DIFF
--- a/.lintspec.toml
+++ b/.lintspec.toml
@@ -17,6 +17,24 @@ notice = "ignored" # since constructors rarely have another purpose than deploym
 dev = "ignored"
 param = "required"
 
+[contract]
+title = "ignored"
+author = "ignored"
+notice = "ignored"
+dev = "ignored"
+
+[interface]
+title = "ignored"
+author = "ignored"
+notice = "ignored"
+dev = "ignored"
+
+[library]
+title = "ignored"
+author = "ignored"
+notice = "ignored"
+dev = "ignored"
+
 [enum]
 notice = "required"
 dev = "ignored"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ rust-version = "1.88.0"
 version = "0.9.1"
 
 [lints.clippy]
-module_name_repetitions = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
+mod_module_files = "warn"
+module_name_repetitions = "allow"
 pedantic = { level = "warn", priority = -1 }
 
 [package.metadata.docs.rs]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,6 +258,7 @@ macro_rules! cli_rule_override {
         for item in $items {
             match item {
                 ContractType::Contract => $config.contracts.title = $req,
+                ContractType::Interface => $config.interfaces.title = $req,
             }
         }
     };
@@ -265,6 +266,7 @@ macro_rules! cli_rule_override {
         for item in $items {
             match item {
                 ContractType::Contract => $config.contracts.author = $req,
+                ContractType::Interface => $config.interfaces.author = $req,
             }
         }
     };
@@ -272,6 +274,7 @@ macro_rules! cli_rule_override {
         for item in $items {
             match item {
                 ItemType::Contract => $config.contracts.$tag = $req,
+                ItemType::Interface => $config.contracts.$tag = $req,
                 ItemType::Constructor => $config.constructors.$tag = $req,
                 ItemType::Enum => $config.enums.$tag = $req,
                 ItemType::Error => $config.errors.$tag = $req,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,7 +12,7 @@ use miette::{LabeledSpan, MietteDiagnostic, NamedSource};
 
 use crate::{
     config::{Config, Req},
-    definitions::ItemType,
+    definitions::{ContractType, ItemType},
     lint::{FileDiagnostics, ItemDiagnostics},
 };
 
@@ -94,6 +94,38 @@ pub struct Args {
     /// Can be set with `--skip-version-detection` (means true), `--skip-version-detection=true` or `--skip-version-detection=false`.
     #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub skip_version_detection: Option<bool>,
+
+    /// Ignore `@title` for these items (can be used more than once)
+    #[arg(long)]
+    pub title_ignored: Vec<ContractType>,
+
+    /// Enforce `@title` for these items (can be used more than once)
+    ///
+    /// This takes precedence over `--title-ignored`.
+    #[arg(long)]
+    pub title_required: Vec<ContractType>,
+
+    /// Forbid `@title` for these items (can be used more than once)
+    ///
+    /// This takes precedence over `--title-required`.
+    #[arg(long)]
+    pub title_forbidden: Vec<ContractType>,
+
+    /// Ignore `@author` for these items (can be used more than once)
+    #[arg(long)]
+    pub author_ignored: Vec<ContractType>,
+
+    /// Enforce `@author` for these items (can be used more than once)
+    ///
+    /// This takes precedence over `--author-ignored`.
+    #[arg(long)]
+    pub author_required: Vec<ContractType>,
+
+    /// Forbid `@author` for these items (can be used more than once)
+    ///
+    /// This takes precedence over `--author-required`.
+    #[arg(long)]
+    pub author_forbidden: Vec<ContractType>,
 
     /// Ignore `@notice` for these items (can be used more than once)
     #[arg(long)]
@@ -222,9 +254,24 @@ macro_rules! cli_rule_override {
             }
         }
     };
+    ($config:expr, $items:expr, title, $req:expr) => {
+        for item in $items {
+            match item {
+                ContractType::Contract => $config.contracts.title = $req,
+            }
+        }
+    };
+    ($config:expr, $items:expr, author, $req:expr) => {
+        for item in $items {
+            match item {
+                ContractType::Contract => $config.contracts.author = $req,
+            }
+        }
+    };
     ($config:expr, $items:expr, $tag:ident, $req:expr) => {
         for item in $items {
             match item {
+                ItemType::Contract => $config.contracts.$tag = $req,
                 ItemType::Constructor => $config.constructors.$tag = $req,
                 ItemType::Enum => $config.enums.$tag = $req,
                 ItemType::Error => $config.errors.$tag = $req,
@@ -281,6 +328,12 @@ pub fn read_config(args: Args) -> Result<Config, Box<figment::Error>> {
         config.lintspec.notice_or_dev = notice_or_dev;
     }
 
+    cli_rule_override!(config, args.title_ignored, title, Req::Ignored);
+    cli_rule_override!(config, args.title_required, title, Req::Required);
+    cli_rule_override!(config, args.title_forbidden, title, Req::Forbidden);
+    cli_rule_override!(config, args.author_ignored, author, Req::Ignored);
+    cli_rule_override!(config, args.author_required, author, Req::Required);
+    cli_rule_override!(config, args.author_forbidden, author, Req::Forbidden);
     cli_rule_override!(config, args.notice_ignored, notice, Req::Ignored);
     cli_rule_override!(config, args.notice_required, notice, Req::Required);
     cli_rule_override!(config, args.notice_forbidden, notice, Req::Forbidden);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,6 +259,7 @@ macro_rules! cli_rule_override {
             match item {
                 ContractType::Contract => $config.contracts.title = $req,
                 ContractType::Interface => $config.interfaces.title = $req,
+                ContractType::Library => $config.libraries.title = $req,
             }
         }
     };
@@ -267,6 +268,7 @@ macro_rules! cli_rule_override {
             match item {
                 ContractType::Contract => $config.contracts.author = $req,
                 ContractType::Interface => $config.interfaces.author = $req,
+                ContractType::Library => $config.libraries.author = $req,
             }
         }
     };
@@ -275,6 +277,7 @@ macro_rules! cli_rule_override {
             match item {
                 ItemType::Contract => $config.contracts.$tag = $req,
                 ItemType::Interface => $config.interfaces.$tag = $req,
+                ItemType::Library => $config.libraries.$tag = $req,
                 ItemType::Constructor => $config.constructors.$tag = $req,
                 ItemType::Enum => $config.enums.$tag = $req,
                 ItemType::Error => $config.errors.$tag = $req,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,7 +274,7 @@ macro_rules! cli_rule_override {
         for item in $items {
             match item {
                 ItemType::Contract => $config.contracts.$tag = $req,
-                ItemType::Interface => $config.contracts.$tag = $req,
+                ItemType::Interface => $config.interfaces.$tag = $req,
                 ItemType::Constructor => $config.constructors.$tag = $req,
                 ItemType::Enum => $config.enums.$tag = $req,
                 ItemType::Error => $config.errors.$tag = $req,

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,6 +145,20 @@ impl Default for NoticeDevRules {
     }
 }
 
+/// Validation rules for contracts, interfaces and libraries
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
+#[non_exhaustive]
+pub struct ContractRules {
+    #[builder(default)]
+    pub title: Req,
+    #[builder(default)]
+    pub author: Req,
+    #[builder(default)]
+    pub notice: Req,
+    #[builder(default)]
+    pub dev: Req,
+}
+
 /// Validation rules for each state variable visibility (private, internal, public)
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, bon::Builder)]
 #[non_exhaustive]
@@ -284,6 +298,11 @@ pub struct Config {
     #[builder(default = WithParamsRules::default_constructor())]
     pub constructors: WithParamsRules,
 
+    /// Validation rules for contracts
+    #[serde(rename = "contract")]
+    #[builder(default)]
+    pub contracts: ContractRules,
+
     /// Validation rules for enums
     #[serde(rename = "enum")]
     #[builder(default)]
@@ -325,6 +344,7 @@ impl Default for Config {
         Self {
             lintspec: BaseConfig::default(),
             output: OutputConfig::default(),
+            contracts: ContractRules::default(),
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
             errors: WithParamsRules::required(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -303,6 +303,11 @@ pub struct Config {
     #[builder(default)]
     pub contracts: ContractRules,
 
+    /// Validation rules for interfaces
+    #[serde(rename = "interface")]
+    #[builder(default)]
+    pub interfaces: ContractRules,
+
     /// Validation rules for enums
     #[serde(rename = "enum")]
     #[builder(default)]
@@ -345,6 +350,7 @@ impl Default for Config {
             lintspec: BaseConfig::default(),
             output: OutputConfig::default(),
             contracts: ContractRules::default(),
+            interfaces: ContractRules::default(),
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
             errors: WithParamsRules::required(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,6 +308,11 @@ pub struct Config {
     #[builder(default)]
     pub interfaces: ContractRules,
 
+    /// Validation rules for libraries
+    #[serde(rename = "library")]
+    #[builder(default)]
+    pub libraries: ContractRules,
+
     /// Validation rules for enums
     #[serde(rename = "enum")]
     #[builder(default)]
@@ -351,6 +356,7 @@ impl Default for Config {
             output: OutputConfig::default(),
             contracts: ContractRules::default(),
             interfaces: ContractRules::default(),
+            libraries: ContractRules::default(),
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
             errors: WithParamsRules::required(),
@@ -410,6 +416,7 @@ mod tests {
             WithReturnsRules::builder().build()
         );
         assert_eq!(NoticeDevRules::default(), NoticeDevRules::builder().build());
+        assert_eq!(ContractRules::default(), ContractRules::builder().build());
         assert_eq!(VariableConfig::default(), VariableConfig::builder().build());
         assert_eq!(
             WithParamsRules::default(),

--- a/src/definitions/contract.rs
+++ b/src/definitions/contract.rs
@@ -1,0 +1,150 @@
+//! Parsing and validation of contract definitions.
+use crate::{
+    lint::{ItemDiagnostics, check_author, check_notice_and_dev, check_title},
+    natspec::NatSpec,
+};
+
+use super::{ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
+
+/// A contract definition
+#[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
+#[builder(on(String, into))]
+pub struct ContractDefinition {
+    /// The name of the contract
+    pub name: String,
+
+    /// The span of the contract definition
+    pub span: TextRange,
+
+    /// The [`NatSpec`] associated with the contract definition, if any
+    pub natspec: Option<NatSpec>,
+}
+
+impl SourceItem for ContractDefinition {
+    fn item_type(&self) -> ItemType {
+        ItemType::Contract
+    }
+
+    fn parent(&self) -> Option<Parent> {
+        None
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn span(&self) -> TextRange {
+        self.span.clone()
+    }
+}
+
+impl Validate for ContractDefinition {
+    fn validate(&self, options: &ValidationOptions) -> ItemDiagnostics {
+        let opts = &options.contracts;
+        let mut out = ItemDiagnostics {
+            parent: self.parent(),
+            item_type: self.item_type(),
+            name: self.name(),
+            span: self.span(),
+            diags: vec![],
+        };
+        out.diags
+            .extend(check_title(&self.natspec, opts.title, self.span()));
+        out.diags
+            .extend(check_author(&self.natspec, opts.author, self.span()));
+        out.diags.extend(check_notice_and_dev(
+            &self.natspec,
+            opts.notice,
+            opts.dev,
+            options.notice_or_dev,
+            self.span(),
+        ));
+        out
+    }
+}
+
+#[cfg(all(test, feature = "slang"))]
+mod tests {
+    use std::sync::LazyLock;
+
+    use similar_asserts::assert_eq;
+
+    use crate::{
+        config::{ContractRules, Req},
+        definitions::Definition,
+        parser::{Parse as _, slang::SlangParser},
+    };
+
+    use super::*;
+
+    static OPTIONS: LazyLock<ValidationOptions> = LazyLock::new(|| {
+        ValidationOptions::builder()
+            .inheritdoc(false)
+            .contracts(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build(),
+            )
+            .build()
+    });
+
+    fn parse_file(contents: &str) -> ContractDefinition {
+        let mut parser = SlangParser::builder().skip_version_detection(true).build();
+        let doc = parser
+            .parse_document(contents.as_bytes(), None::<std::path::PathBuf>, false)
+            .unwrap();
+        doc.definitions
+            .into_iter()
+            .find_map(Definition::to_contract)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_contract() {
+        let contents = "/// @title Contract
+        /// @author Me
+        /// @notice This is a contract
+        contract Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_contract_no_natspec() {
+        let contents = "contract Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert_eq!(res.diags.len(), 3);
+        assert_eq!(res.diags[0].message, "@title is missing");
+        assert_eq!(res.diags[1].message, "@author is missing");
+        assert_eq!(res.diags[2].message, "@notice is missing");
+    }
+
+    #[test]
+    fn test_contract_multiline() {
+        let contents = "/**
+         * @title Contract
+         * @author Me
+         * @notice This is a contract
+         */
+        contract Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_contract_inheritdoc() {
+        // inheritdoc should be ignored as it doesn't apply to contracts
+        let contents = "/// @inheritdoc ITest
+        contract Test is Foo {}";
+        let res = parse_file(contents).validate(
+            &ValidationOptions::builder()
+                .contracts(ContractRules::builder().title(Req::Required).build())
+                .build(),
+        );
+        assert_eq!(res.diags.len(), 1);
+        assert_eq!(res.diags[0].message, "@title is missing");
+    }
+}

--- a/src/definitions/interface.rs
+++ b/src/definitions/interface.rs
@@ -1,0 +1,150 @@
+//! Parsing and validation of interface definitions.
+use crate::{
+    lint::{ItemDiagnostics, check_author, check_notice_and_dev, check_title},
+    natspec::NatSpec,
+};
+
+use super::{ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
+
+/// An interface definition
+#[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
+#[builder(on(String, into))]
+pub struct InterfaceDefinition {
+    /// The name of the interface
+    pub name: String,
+
+    /// The span of the interface definition
+    pub span: TextRange,
+
+    /// The [`NatSpec`] associated with the interface definition, if any
+    pub natspec: Option<NatSpec>,
+}
+
+impl SourceItem for InterfaceDefinition {
+    fn item_type(&self) -> ItemType {
+        ItemType::Interface
+    }
+
+    fn parent(&self) -> Option<Parent> {
+        None
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn span(&self) -> TextRange {
+        self.span.clone()
+    }
+}
+
+impl Validate for InterfaceDefinition {
+    fn validate(&self, options: &ValidationOptions) -> ItemDiagnostics {
+        let opts = &options.interfaces;
+        let mut out = ItemDiagnostics {
+            parent: self.parent(),
+            item_type: self.item_type(),
+            name: self.name(),
+            span: self.span(),
+            diags: vec![],
+        };
+        out.diags
+            .extend(check_title(&self.natspec, opts.title, self.span()));
+        out.diags
+            .extend(check_author(&self.natspec, opts.author, self.span()));
+        out.diags.extend(check_notice_and_dev(
+            &self.natspec,
+            opts.notice,
+            opts.dev,
+            options.notice_or_dev,
+            self.span(),
+        ));
+        out
+    }
+}
+
+#[cfg(all(test, feature = "slang"))]
+mod tests {
+    use std::sync::LazyLock;
+
+    use similar_asserts::assert_eq;
+
+    use crate::{
+        config::{ContractRules, Req},
+        definitions::Definition,
+        parser::{Parse as _, slang::SlangParser},
+    };
+
+    use super::*;
+
+    static OPTIONS: LazyLock<ValidationOptions> = LazyLock::new(|| {
+        ValidationOptions::builder()
+            .inheritdoc(false)
+            .interfaces(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build(),
+            )
+            .build()
+    });
+
+    fn parse_file(contents: &str) -> InterfaceDefinition {
+        let mut parser = SlangParser::builder().skip_version_detection(true).build();
+        let doc = parser
+            .parse_document(contents.as_bytes(), None::<std::path::PathBuf>, false)
+            .unwrap();
+        doc.definitions
+            .into_iter()
+            .find_map(Definition::to_interface)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_interface() {
+        let contents = "/// @title Interface
+        /// @author Me
+        /// @notice This is an interface
+        interface Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_interface_no_natspec() {
+        let contents = "interface Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert_eq!(res.diags.len(), 3);
+        assert_eq!(res.diags[0].message, "@title is missing");
+        assert_eq!(res.diags[1].message, "@author is missing");
+        assert_eq!(res.diags[2].message, "@notice is missing");
+    }
+
+    #[test]
+    fn test_interface_multiline() {
+        let contents = "/**
+         * @title Interface
+         * @author Me
+         * @notice This is an interface
+         */
+        interface Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_interface_inheritdoc() {
+        // inheritdoc should be ignored as it doesn't apply to interfaces
+        let contents = "/// @inheritdoc ITest
+        interface Test is Foo {}";
+        let res = parse_file(contents).validate(
+            &ValidationOptions::builder()
+                .interfaces(ContractRules::builder().title(Req::Required).build())
+                .build(),
+        );
+        assert_eq!(res.diags.len(), 1);
+        assert_eq!(res.diags[0].message, "@title is missing");
+    }
+}

--- a/src/definitions/library.rs
+++ b/src/definitions/library.rs
@@ -1,0 +1,150 @@
+//! Parsing and validation of library definitions.
+use crate::{
+    lint::{ItemDiagnostics, check_author, check_notice_and_dev, check_title},
+    natspec::NatSpec,
+};
+
+use super::{ItemType, Parent, SourceItem, TextRange, Validate, ValidationOptions};
+
+/// A library definition
+#[derive(Debug, Clone, bon::Builder)]
+#[non_exhaustive]
+#[builder(on(String, into))]
+pub struct LibraryDefinition {
+    /// The name of the library
+    pub name: String,
+
+    /// The span of the library definition
+    pub span: TextRange,
+
+    /// The [`NatSpec`] associated with the library definition, if any
+    pub natspec: Option<NatSpec>,
+}
+
+impl SourceItem for LibraryDefinition {
+    fn item_type(&self) -> ItemType {
+        ItemType::Library
+    }
+
+    fn parent(&self) -> Option<Parent> {
+        None
+    }
+
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn span(&self) -> TextRange {
+        self.span.clone()
+    }
+}
+
+impl Validate for LibraryDefinition {
+    fn validate(&self, options: &ValidationOptions) -> ItemDiagnostics {
+        let opts = &options.libraries;
+        let mut out = ItemDiagnostics {
+            parent: self.parent(),
+            item_type: self.item_type(),
+            name: self.name(),
+            span: self.span(),
+            diags: vec![],
+        };
+        out.diags
+            .extend(check_title(&self.natspec, opts.title, self.span()));
+        out.diags
+            .extend(check_author(&self.natspec, opts.author, self.span()));
+        out.diags.extend(check_notice_and_dev(
+            &self.natspec,
+            opts.notice,
+            opts.dev,
+            options.notice_or_dev,
+            self.span(),
+        ));
+        out
+    }
+}
+
+#[cfg(all(test, feature = "slang"))]
+mod tests {
+    use std::sync::LazyLock;
+
+    use similar_asserts::assert_eq;
+
+    use crate::{
+        config::{ContractRules, Req},
+        definitions::Definition,
+        parser::{Parse as _, slang::SlangParser},
+    };
+
+    use super::*;
+
+    static OPTIONS: LazyLock<ValidationOptions> = LazyLock::new(|| {
+        ValidationOptions::builder()
+            .inheritdoc(false)
+            .libraries(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build(),
+            )
+            .build()
+    });
+
+    fn parse_file(contents: &str) -> LibraryDefinition {
+        let mut parser = SlangParser::builder().skip_version_detection(true).build();
+        let doc = parser
+            .parse_document(contents.as_bytes(), None::<std::path::PathBuf>, false)
+            .unwrap();
+        doc.definitions
+            .into_iter()
+            .find_map(Definition::to_library)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_library() {
+        let contents = "/// @title Library
+        /// @author Me
+        /// @notice This is a library
+        library Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_library_no_natspec() {
+        let contents = "library Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert_eq!(res.diags.len(), 3);
+        assert_eq!(res.diags[0].message, "@title is missing");
+        assert_eq!(res.diags[1].message, "@author is missing");
+        assert_eq!(res.diags[2].message, "@notice is missing");
+    }
+
+    #[test]
+    fn test_library_multiline() {
+        let contents = "/**
+         * @title Library
+         * @author Me
+         * @notice This is a library
+         */
+        library Test {}";
+        let res = parse_file(contents).validate(&OPTIONS);
+        assert!(res.diags.is_empty(), "{:#?}", res.diags);
+    }
+
+    #[test]
+    fn test_library_inheritdoc() {
+        // inheritdoc should be ignored as it doesn't apply to libraries
+        let contents = "/// @inheritdoc ITest
+        library Test {}";
+        let res = parse_file(contents).validate(
+            &ValidationOptions::builder()
+                .libraries(ContractRules::builder().title(Req::Required).build())
+                .build(),
+        );
+        assert_eq!(res.diags.len(), 1);
+        assert_eq!(res.diags[0].message, "@title is missing");
+    }
+}

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -166,6 +166,10 @@ pub struct ValidationOptions {
     #[builder(default)]
     pub contracts: ContractRules,
 
+    /// Validation options for interfaces
+    #[builder(default)]
+    pub interfaces: ContractRules,
+
     /// Validation options for constructors
     #[builder(default = WithParamsRules::default_constructor())]
     pub constructors: WithParamsRules,
@@ -210,6 +214,7 @@ impl Default for ValidationOptions {
             inheritdoc_override: false,
             notice_or_dev: false,
             contracts: ContractRules::default(),
+            interfaces: ContractRules::default(),
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
             errors: WithParamsRules::required(),
@@ -230,6 +235,7 @@ impl From<Config> for ValidationOptions {
             inheritdoc_override: value.lintspec.inheritdoc_override,
             notice_or_dev: value.lintspec.notice_or_dev,
             contracts: value.contracts,
+            interfaces: value.interfaces,
             constructors: value.constructors,
             enums: value.enums,
             errors: value.errors,
@@ -250,6 +256,7 @@ impl From<&Config> for ValidationOptions {
             inheritdoc_override: value.lintspec.inheritdoc_override,
             notice_or_dev: value.lintspec.notice_or_dev,
             contracts: value.contracts.clone(),
+            interfaces: value.interfaces.clone(),
             constructors: value.constructors.clone(),
             enums: value.enums.clone(),
             errors: value.errors.clone(),
@@ -590,6 +597,8 @@ mod tests {
         let options = ValidationOptions::from(&config);
         assert_eq!(config.lintspec.inheritdoc, options.inheritdoc);
         assert_eq!(config.lintspec.notice_or_dev, options.notice_or_dev);
+        assert_eq!(config.contracts, options.contracts);
+        assert_eq!(config.interfaces, options.interfaces);
         assert_eq!(config.constructors, options.constructors);
         assert_eq!(config.enums, options.enums);
         assert_eq!(config.errors, options.errors);
@@ -604,6 +613,14 @@ mod tests {
                 BaseConfig::builder()
                     .inheritdoc(false)
                     .notice_or_dev(true)
+                    .build(),
+            )
+            .contracts(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .dev(Req::Required)
+                    .notice(Req::Forbidden)
                     .build(),
             )
             .constructors(WithParamsRules::builder().dev(Req::Required).build())
@@ -626,6 +643,8 @@ mod tests {
         let options = ValidationOptions::from(&config);
         assert_eq!(config.lintspec.inheritdoc, options.inheritdoc);
         assert_eq!(config.lintspec.notice_or_dev, options.notice_or_dev);
+        assert_eq!(config.contracts, options.contracts);
+        assert_eq!(config.interfaces, options.interfaces);
         assert_eq!(config.constructors, options.constructors);
         assert_eq!(config.enums, options.enums);
         assert_eq!(config.errors, options.errors);

--- a/src/lint.rs
+++ b/src/lint.rs
@@ -170,6 +170,10 @@ pub struct ValidationOptions {
     #[builder(default)]
     pub interfaces: ContractRules,
 
+    /// Validation options for libraries
+    #[builder(default)]
+    pub libraries: ContractRules,
+
     /// Validation options for constructors
     #[builder(default = WithParamsRules::default_constructor())]
     pub constructors: WithParamsRules,
@@ -215,6 +219,7 @@ impl Default for ValidationOptions {
             notice_or_dev: false,
             contracts: ContractRules::default(),
             interfaces: ContractRules::default(),
+            libraries: ContractRules::default(),
             constructors: WithParamsRules::default_constructor(),
             enums: WithParamsRules::default(),
             errors: WithParamsRules::required(),
@@ -236,6 +241,7 @@ impl From<Config> for ValidationOptions {
             notice_or_dev: value.lintspec.notice_or_dev,
             contracts: value.contracts,
             interfaces: value.interfaces,
+            libraries: value.libraries,
             constructors: value.constructors,
             enums: value.enums,
             errors: value.errors,
@@ -257,6 +263,7 @@ impl From<&Config> for ValidationOptions {
             notice_or_dev: value.lintspec.notice_or_dev,
             contracts: value.contracts.clone(),
             interfaces: value.interfaces.clone(),
+            libraries: value.libraries.clone(),
             constructors: value.constructors.clone(),
             enums: value.enums.clone(),
             errors: value.errors.clone(),
@@ -599,6 +606,7 @@ mod tests {
         assert_eq!(config.lintspec.notice_or_dev, options.notice_or_dev);
         assert_eq!(config.contracts, options.contracts);
         assert_eq!(config.interfaces, options.interfaces);
+        assert_eq!(config.libraries, options.libraries);
         assert_eq!(config.constructors, options.constructors);
         assert_eq!(config.enums, options.enums);
         assert_eq!(config.errors, options.errors);
@@ -623,6 +631,22 @@ mod tests {
                     .notice(Req::Forbidden)
                     .build(),
             )
+            .interfaces(
+                ContractRules::builder()
+                    .title(Req::Ignored)
+                    .author(Req::Forbidden)
+                    .dev(Req::Forbidden)
+                    .notice(Req::Required)
+                    .build(),
+            )
+            .libraries(
+                ContractRules::builder()
+                    .title(Req::Forbidden)
+                    .author(Req::Ignored)
+                    .dev(Req::Required)
+                    .notice(Req::Ignored)
+                    .build(),
+            )
             .constructors(WithParamsRules::builder().dev(Req::Required).build())
             .enums(WithParamsRules::builder().param(Req::Required).build())
             .errors(WithParamsRules::builder().notice(Req::Forbidden).build())
@@ -645,6 +669,7 @@ mod tests {
         assert_eq!(config.lintspec.notice_or_dev, options.notice_or_dev);
         assert_eq!(config.contracts, options.contracts);
         assert_eq!(config.interfaces, options.interfaces);
+        assert_eq!(config.libraries, options.libraries);
         assert_eq!(config.constructors, options.constructors);
         assert_eq!(config.enums, options.enums);
         assert_eq!(config.errors, options.errors);

--- a/src/natspec.rs
+++ b/src/natspec.rs
@@ -99,6 +99,16 @@ impl NatSpec {
     pub fn has_dev(&self) -> bool {
         self.items.iter().any(|n| n.kind.is_dev())
     }
+
+    #[must_use]
+    pub fn has_title(&self) -> bool {
+        self.items.iter().any(|n| n.kind.is_title())
+    }
+
+    #[must_use]
+    pub fn has_author(&self) -> bool {
+        self.items.iter().any(|n| n.kind.is_author())
+    }
 }
 
 /// A single `NatSpec` item

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -617,6 +617,7 @@ pub fn extract_comment(cursor: &Cursor, returns: &[Identifier]) -> Result<Option
             ));
         } else if cursor.node().is_terminal_with_kinds(&[
             TerminalKind::ContractKeyword,
+            TerminalKind::InterfaceKeyword,
             TerminalKind::ConstructorKeyword,
             TerminalKind::EnumKeyword,
             TerminalKind::ErrorKeyword,

--- a/src/parser/slang.rs
+++ b/src/parser/slang.rs
@@ -92,9 +92,11 @@ impl SlangParser {
                 7 => Some(
                     VariableDeclaration::extract(m).unwrap_or_else(Definition::NatspecParsingError),
                 ),
-                8 => Some(
-                    ContractDefinition::extract(m).unwrap_or_else(Definition::NatspecParsingError),
-                ),
+                8 => {
+                    let def = ContractDefinition::extract(m)
+                        .unwrap_or_else(Definition::NatspecParsingError);
+                    if out.contains(&def) { None } else { Some(def) }
+                }
                 _ => unreachable!(),
             };
             if let Some(def) = def {

--- a/src/parser/solar.rs
+++ b/src/parser/solar.rs
@@ -423,6 +423,9 @@ trait Extract {
 
 impl Extract for &solar_parse::ast::ItemContract<'_> {
     fn extract_definition(self, item: &Item, visitor: &mut LintspecVisitor) -> Option<Definition> {
+        if matches!(self.kind, ContractKind::Interface | ContractKind::Library) {
+            return None;
+        }
         let name = self.name.to_string();
 
         let (natspec, span) = match extract_natspec(&item.docs, visitor, &[]) {

--- a/test-data/InterfaceSample.sol
+++ b/test-data/InterfaceSample.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.19;
 
+/// @title The interface
 interface IInterfacedSample {
     /**
      * @notice Greets the caller

--- a/test-data/LibrarySample.sol
+++ b/test-data/LibrarySample.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity =0.8.19;
 
+/// @title StringUtils
 library StringUtils {
     function nothing(string memory input) public pure returns (string memory) {
         return input;

--- a/tests/snapshots/tests_basic_sample__all.snap
+++ b/tests/snapshots/tests_basic_sample__all.snap
@@ -1,11 +1,23 @@
 ---
 source: tests/tests-basic-sample.rs
-expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc_override(true).constructors(WithParamsRules::required()).enums(WithParamsRules::required()).modifiers(WithParamsRules::required()).structs(WithParamsRules::required()).variables(VariableConfig::builder().private(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).internal(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).build(),).build(),\ntrue,)"
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc_override(true).constructors(WithParamsRules::required()).enums(WithParamsRules::required()).modifiers(WithParamsRules::required()).structs(WithParamsRules::required()).variables(VariableConfig::builder().private(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).internal(NoticeDevRules::builder().notice(Req::Required).dev(Req::Required).build(),).build(),).contracts(ContractRules::builder().title(Req::Required).author(Req::Required).notice(Req::Required).build()).build(),\ntrue,)"
 ---
+./test-data/BasicSample.sol:4:1
+contract AbstractBasic
+  @title is missing
+  @author is missing
+  @notice is missing
+
 ./test-data/BasicSample.sol:5:5
 function AbstractBasic.overriddenFunction
   @notice is missing
   @return _returned is missing
+
+./test-data/BasicSample.sol:8:1
+contract BasicSample
+  @title is missing
+  @author is missing
+  @notice is missing
 
 ./test-data/BasicSample.sol:9:5
 struct BasicSample.TestStruct
@@ -65,6 +77,12 @@ function BasicSample.virtualFunction
 ./test-data/BasicSample.sol:111:5
 modifier BasicSample.transferFee
   @param _receiver is missing
+
+./test-data/BasicSample.sol:129:1
+contract ChildContract
+  @title is missing
+  @author is missing
+  @notice is missing
 
 ./test-data/BasicSample.sol:130:5
 constructor ChildContract.constructor

--- a/tests/snapshots/tests_basic_sample__contract.snap
+++ b/tests/snapshots/tests_basic_sample__contract.snap
@@ -1,0 +1,67 @@
+---
+source: tests/tests-basic-sample.rs
+expression: "snapshot_content(\"./test-data/BasicSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).contracts(ContractRules::builder().title(Req::Required).author(Req::Required).notice(Req::Required).build()).build(),\ntrue,)"
+---
+./test-data/BasicSample.sol:4:1
+contract AbstractBasic
+  @title is missing
+  @author is missing
+  @notice is missing
+
+./test-data/BasicSample.sol:5:5
+function AbstractBasic.overriddenFunction
+  @notice is missing
+  @return _returned is missing
+
+./test-data/BasicSample.sol:8:1
+contract BasicSample
+  @title is missing
+  @author is missing
+  @notice is missing
+
+./test-data/BasicSample.sol:23:5
+error BasicSample.BasicSample_SomeError
+  @param _param1 is missing
+
+./test-data/BasicSample.sol:28:5
+event BasicSample.BasicSample_BasicEvent
+  @param _param1 is missing
+
+./test-data/BasicSample.sol:39:5
+variable BasicSample.somePublicNumber
+  @return is missing
+
+./test-data/BasicSample.sol:44:5
+constructor BasicSample.constructor
+  @param _randomFlag is missing
+
+./test-data/BasicSample.sol:46:5
+function BasicSample.externalSimple
+  @param _name is present more than once
+
+./test-data/BasicSample.sol:93:5
+function BasicSample.externalSimpleMultipleUnnamedReturn
+  @return missing for unnamed return #2
+
+./test-data/BasicSample.sol:102:5
+function BasicSample.overriddenFunction
+  @return _returned is missing
+
+./test-data/BasicSample.sol:109:5
+function BasicSample.virtualFunction
+  @notice is missing
+  @return _returned is missing
+
+./test-data/BasicSample.sol:111:5
+modifier BasicSample.transferFee
+  @param _receiver is missing
+
+./test-data/BasicSample.sol:129:1
+contract ChildContract
+  @title is missing
+  @author is missing
+  @notice is missing
+
+./test-data/BasicSample.sol:132:5
+modifier ChildContract.transferFee
+  @notice is missing

--- a/tests/snapshots/tests_interface_sample__interface.snap
+++ b/tests/snapshots/tests_interface_sample__interface.snap
@@ -4,15 +4,14 @@ expression: "snapshot_content(\"./test-data/InterfaceSample.sol\",\n&ValidationO
 ---
 ./test-data/InterfaceSample.sol:4:1
 interface IInterfacedSample
-  @title is missing
   @author is missing
   @notice is missing
 
-./test-data/InterfaceSample.sol:5:5
+./test-data/InterfaceSample.sol:6:5
 function IInterfacedSample.greet
   @return _greeting is missing
 
-./test-data/InterfaceSample.sol:14:5
+./test-data/InterfaceSample.sol:15:5
 function InterfacedSample.greet
   @notice is missing
   @return _greeting is missing

--- a/tests/snapshots/tests_interface_sample__interface.snap
+++ b/tests/snapshots/tests_interface_sample__interface.snap
@@ -1,7 +1,13 @@
 ---
 source: tests/tests-interface-sample.rs
-expression: "snapshot_content(\"./test-data/InterfaceSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).build(), true,)"
+expression: "snapshot_content(\"./test-data/InterfaceSample.sol\",\n&ValidationOptions::builder().inheritdoc(false).interfaces(ContractRules::builder().title(Req::Required).author(Req::Required).notice(Req::Required).build()).build(),\ntrue,)"
 ---
+./test-data/InterfaceSample.sol:4:1
+interface IInterfacedSample
+  @title is missing
+  @author is missing
+  @notice is missing
+
 ./test-data/InterfaceSample.sol:5:5
 function IInterfacedSample.greet
   @return _greeting is missing

--- a/tests/snapshots/tests_library_sample__library.snap
+++ b/tests/snapshots/tests_library_sample__library.snap
@@ -1,7 +1,13 @@
 ---
 source: tests/tests-library-sample.rs
-expression: "snapshot_content(\"./test-data/LibrarySample.sol\",\n&ValidationOptions::builder().inheritdoc(false).build(), true,)"
+expression: "snapshot_content(\"./test-data/LibrarySample.sol\",\n&ValidationOptions::builder().inheritdoc(false).libraries(ContractRules::builder().title(Req::Required).author(Req::Required).notice(Req::Required).build()).build(),\ntrue,)"
 ---
+./test-data/LibrarySample.sol:4:1
+library StringUtils
+  @title is missing
+  @author is missing
+  @notice is missing
+
 ./test-data/LibrarySample.sol:5:5
 function StringUtils.nothing
   @notice is missing

--- a/tests/snapshots/tests_library_sample__library.snap
+++ b/tests/snapshots/tests_library_sample__library.snap
@@ -4,11 +4,10 @@ expression: "snapshot_content(\"./test-data/LibrarySample.sol\",\n&ValidationOpt
 ---
 ./test-data/LibrarySample.sol:4:1
 library StringUtils
-  @title is missing
   @author is missing
   @notice is missing
 
-./test-data/LibrarySample.sol:5:5
+./test-data/LibrarySample.sol:6:5
 function StringUtils.nothing
   @notice is missing
   @param input is missing

--- a/tests/snapshots/tests_parser_test__contract.snap
+++ b/tests/snapshots/tests_parser_test__contract.snap
@@ -1,0 +1,63 @@
+---
+source: tests/tests-parser-test.rs
+expression: "snapshot_content(\"./test-data/ParserTest.sol\",\n&ValidationOptions::builder().inheritdoc(false).contracts(ContractRules::builder().title(Req::Required).author(Req::Required).notice(Req::Required).build()).build(),\ntrue,)"
+---
+./test-data/ParserTest.sol:8:3
+error IParserTest.SimpleError
+  @param _param1 is missing
+  @param _param2 is missing
+
+./test-data/ParserTest.sol:11:3
+event IParserTest.SimpleEvent
+  @param _param1 is missing
+  @param _param2 is missing
+
+./test-data/ParserTest.sol:47:3
+function IParserTest.SOME_CONSTANT
+  @return _returned is missing
+
+./test-data/ParserTest.sol:51:1
+contract ParserTest
+  @title is missing
+  @author is missing
+
+./test-data/ParserTest.sol:119:1
+contract ParserTestFunny
+  @title is missing
+  @author is missing
+  @notice is missing
+
+./test-data/ParserTest.sol:121:3
+struct ParserTestFunny.SimpleStruct
+  @notice is missing
+
+./test-data/ParserTest.sol:128:3
+modifier ParserTestFunny.someModifier
+  @notice is missing
+
+./test-data/ParserTest.sol:137:3
+variable ParserTestFunny.SOME_CONSTANT
+  @notice is missing
+  @return is missing
+
+./test-data/ParserTest.sol:145:3
+function ParserTestFunny.viewFunctionWithParams
+  @notice is missing
+  @param _param1 is missing
+  @param _param2 is missing
+  @return missing for unnamed return #1
+
+./test-data/ParserTest.sol:150:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @return missing for unnamed return #1
+
+./test-data/ParserTest.sol:183:3
+function ParserTestFunny._viewInternal
+  @notice is missing
+  @param _paramName is missing
+  @return _returned is missing
+
+./test-data/ParserTest.sol:190:3
+function ParserTestFunny._viewBlockLinterFail
+  @notice is missing

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "slang")]
 use lintspec::{
-    config::{NoticeDevRules, Req, VariableConfig, WithParamsRules},
+    config::{ContractRules, NoticeDevRules, Req, VariableConfig, WithParamsRules},
     lint::ValidationOptions,
 };
 
@@ -58,6 +58,24 @@ fn test_enum() {
         &ValidationOptions::builder()
             .inheritdoc(false)
             .enums(WithParamsRules::required())
+            .build(),
+        true,
+    ));
+}
+
+#[test]
+fn test_contract() {
+    insta::assert_snapshot!(snapshot_content(
+        "./test-data/BasicSample.sol",
+        &ValidationOptions::builder()
+            .inheritdoc(false)
+            .contracts(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build()
+            )
             .build(),
         true,
     ));

--- a/tests/tests-basic-sample.rs
+++ b/tests/tests-basic-sample.rs
@@ -107,6 +107,13 @@ fn test_all() {
                     )
                     .build(),
             )
+            .contracts(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build()
+            )
             .build(),
         true,
     ));

--- a/tests/tests-interface-sample.rs
+++ b/tests/tests-interface-sample.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "slang")]
-use lintspec::lint::ValidationOptions;
+use lintspec::{
+    config::{ContractRules, Req},
+    lint::ValidationOptions,
+};
 
 mod common;
 use common::*;
@@ -8,7 +11,16 @@ use common::*;
 fn test_interface() {
     insta::assert_snapshot!(snapshot_content(
         "./test-data/InterfaceSample.sol",
-        &ValidationOptions::builder().inheritdoc(false).build(),
+        &ValidationOptions::builder()
+            .inheritdoc(false)
+            .interfaces(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build()
+            )
+            .build(),
         true,
     ));
 }

--- a/tests/tests-library-sample.rs
+++ b/tests/tests-library-sample.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "slang")]
-use lintspec::lint::ValidationOptions;
+use lintspec::{
+    config::{ContractRules, Req},
+    lint::ValidationOptions,
+};
 
 mod common;
 use common::*;
@@ -8,7 +11,16 @@ use common::*;
 fn test_library() {
     insta::assert_snapshot!(snapshot_content(
         "./test-data/LibrarySample.sol",
-        &ValidationOptions::builder().inheritdoc(false).build(),
+        &ValidationOptions::builder()
+            .inheritdoc(false)
+            .libraries(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build()
+            )
+            .build(),
         true,
     ));
 }

--- a/tests/tests-parser-test.rs
+++ b/tests/tests-parser-test.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "slang")]
-use lintspec::{config::WithParamsRules, lint::ValidationOptions};
+use lintspec::{
+    config::{ContractRules, Req, WithParamsRules},
+    lint::ValidationOptions,
+};
 
 mod common;
 use common::*;
@@ -53,6 +56,24 @@ fn test_enum() {
         &ValidationOptions::builder()
             .inheritdoc(false)
             .enums(WithParamsRules::required())
+            .build(),
+        true,
+    ));
+}
+
+#[test]
+fn test_contract() {
+    insta::assert_snapshot!(snapshot_content(
+        "./test-data/ParserTest.sol",
+        &ValidationOptions::builder()
+            .inheritdoc(false)
+            .contracts(
+                ContractRules::builder()
+                    .title(Req::Required)
+                    .author(Req::Required)
+                    .notice(Req::Required)
+                    .build()
+            )
             .build(),
         true,
     ));


### PR DESCRIPTION
This PR introduces support for contracts, interfaces, and libraries. That is, users can now decide to enforce or forbid certain NatSpec tags in doc-comments for those source items.

The following can be configured:
- `@title`
- `@author`
- `@notice`
- `@dev`