### PR TITLE
chore!: update msrv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main workflow
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
 
 env:
@@ -12,10 +12,49 @@ permissions:
   contents: read
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  feature-checks-msrv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: taiki-e/install-action@cargo-hack
+      - name: cargo hack
+        env:
+          RUSTUP_TOOLCHAIN: 1.94.1
+        run: |
+          cargo hack -p lintspec-core check --feature-powerset
+          cargo hack -p lintspec check --feature-powerset --at-least-one-of solar,slang
+
+  clippy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - run: cargo clippy --all-targets --all-features
+        env:
+          RUSTFLAGS: -Dwarnings
+
   build-test:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
@@ -38,21 +77,6 @@ jobs:
           cache-on-failure: true
       - run: cargo test --doc
 
-  clippy:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - run: cargo clippy --all-targets --all-features
-        env:
-          RUSTFLAGS: -Dwarnings
-
   docs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -65,31 +89,6 @@ jobs:
       - run: cargo +nightly doc --all-features --no-deps --document-private-items
         env:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"
-
-  fmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - run: cargo fmt --all --check
-
-  feature-checks:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-hack
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: cargo hack
-        run: |
-          cargo hack -p lintspec-core check --feature-powerset
-          cargo hack -p lintspec check --feature-powerset --at-least-one-of solar,slang
 
   deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,12 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: dtolnay/rust-toolchain@stable # correct version will be downloaded by cargo hack
       - uses: taiki-e/install-action@cargo-hack
       - name: cargo hack
-        env:
-          RUSTUP_TOOLCHAIN: 1.94.1
         run: |
-          cargo hack -p lintspec-core check --feature-powerset
-          cargo hack -p lintspec check --feature-powerset --at-least-one-of solar,slang
+          cargo hack --rust-version -p lintspec-core check --feature-powerset
+          cargo hack --rust-version -p lintspec check --feature-powerset --at-least-one-of solar,slang
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -549,9 +549,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -594,9 +594,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -703,18 +703,6 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
@@ -726,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1103,18 +1091,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "7f96a4a12fe60ac746ae295a1a4ecb5bb02debc20856506c8635288065f142de"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -1350,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1436,7 +1424,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1453,9 +1441,9 @@ version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
- "console 0.16.3",
+ "console",
  "once_cell",
- "similar",
+ "similar 2.7.0",
  "tempfile",
 ]
 
@@ -1633,7 +1621,7 @@ dependencies = [
  "thiserror",
  "thiserror-ext",
  "wide",
- "winnow 0.7.15",
+ "winnow 1.0.2",
  "zerocopy",
 ]
 
@@ -1683,9 +1671,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metaslang_bindings"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b83af3074b9e33cf6f3f92586d60ed1a9302390bafbf681d17252dcac7bff4"
+checksum = "1841a4d92255f81729baca29af4189777e7c18f7dffacda562da840e91e9595e"
 dependencies = [
  "metaslang_cst",
  "metaslang_graph_builder",
@@ -1696,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "metaslang_cst"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69550cffd1df2109642f0ea5563df572c37b1ed27f87fd3b569435ebdfb77"
+checksum = "bd83a76d094ba782202ff9bf72df45ecb36812bed6dda8a17901f50141effc67"
 dependencies = [
  "nom",
  "serde",
@@ -1707,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "metaslang_graph_builder"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13b116894dc14e7d5d80024a6585338520b672e0deef9f872be93fc97ff9883"
+checksum = "c904d843dae6ddf99932a92be359f375f9ee7cb0aaded694cac96b3ff91ba23d"
 dependencies = [
  "log",
  "metaslang_cst",
@@ -1722,16 +1710,16 @@ dependencies = [
 
 [[package]]
 name = "metaslang_stack_graphs"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3437d352189d14cb1646c0ba18dfa9e636117825d666c1648ffa92394f7011b"
+checksum = "f9f2bacb435fe62e7e60748c4f01f0638ee4f09f6ec0f10a7eaaa41d939c1034"
 dependencies = [
  "bitvec",
  "controlled-option",
  "either",
  "enumset",
  "fxhash",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "libc",
  "lsp-positions",
  "smallvec",
@@ -1769,12 +1757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,12 +1785,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1885,7 +1866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -2278,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -2563,6 +2544,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93e861ede2e497b47833469b8ec9d5c07fa4c78ce7a00f6eb7dd8168b4b3f"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -2570,26 +2557,25 @@ dependencies = [
 
 [[package]]
 name = "similar-asserts"
-version = "1.7.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+checksum = "997e6ca38e97437973fc9f7f50a50d1274cacd874341a4960fea90067291038c"
 dependencies = [
- "console 0.15.11",
- "similar",
+ "console",
+ "similar 3.1.0",
 ]
 
 [[package]]
 name = "slang_solidity"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d8f3691b7eecf4e80e28433ce0f1f9887a9422c02525ef26baa1dd42d329c2"
+checksum = "1210ed7c8c2f90153f811723c3347b0a8010faae6d3a390ba0f9c752f799c91f"
 dependencies = [
  "metaslang_bindings",
  "metaslang_cst",
  "semver 1.0.28",
  "serde",
- "strum 0.26.3",
- "strum_macros 0.26.4",
+ "strum 0.28.0",
  "thiserror",
 ]
 
@@ -2740,12 +2726,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -2754,16 +2734,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.26.4"
+name = "strum"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -2771,6 +2747,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3228,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,25 +1,27 @@
 [workspace]
-members = ["crates/*"]
 resolver = "3"
+members = ["crates/*"]
 
 [workspace.package]
-authors = ["Valentin Bersier <hi@beeb.li>"]
-categories = ["development-tools", "command-line-utilities"]
 edition = "2024"
-license = "MIT OR Apache-2.0"
+rust-version = "1.94.1"
 readme = "./README.md"
 repository = "https://github.com/beeb/lintspec"
-rust-version = "1.89.0"
+license = "MIT OR Apache-2.0"
+categories = ["command-line-utilities", "development-tools"]
 
 [workspace.lints.clippy]
 allow_attributes = "warn"
+expect_used = "deny"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 mod_module_files = "warn"
 module_name_repetitions = "allow"
 pedantic = { level = "warn", priority = -1 }
 unwrap_used = "deny"
-expect_used = "deny"
+
+[profile.dev.package]
+insta.opt-level = 3
 
 [profile.release]
 lto = "thin"
@@ -28,6 +30,3 @@ lto = "thin"
 [profile.dist]
 inherits = "release"
 lto = "thin"
-
-[profile.dev.package]
-insta.opt-level = 3

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   /></a>
   <a href="https://docs.rs/lintspec/latest/lintspec/"><img
       alt="MSRV"
-      src="https://img.shields.io/badge/MSRV-1.89.0-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
+      src="https://img.shields.io/badge/MSRV-1.94.1-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
       height="20"
   /></a>
   <a href="https://codspeed.io/beeb/lintspec"><img

--- a/crates/lintspec-core/Cargo.toml
+++ b/crates/lintspec-core/Cargo.toml
@@ -1,39 +1,37 @@
 [package]
 name = "lintspec-core"
 version = "0.16.0"
+edition.workspace = true
+rust-version.workspace = true
 description = "Core library for lintspec"
 readme = "./README.md"
-keywords = ["natspec", "solidity", "linter", "documentation"]
-authors.workspace = true
-categories.workspace = true
-edition.workspace = true
-license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
-
-[lints]
-workspace = true
+license.workspace = true
+keywords = ["documentation", "linter", "natspec", "solidity"]
+categories.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[features]
-default = ["solar"]
-clap = ["dep:clap"]
-solar = ["dep:solar-parse"]
-slang = ["dep:regex", "dep:slang_solidity"]
+[[bench]]
+harness = false
+name = "parser"
+
+[[bench]]
+harness = false
+name = "lint"
 
 [dependencies]
 bon = "3.3.2"
 clap = { version = "4.5.29", features = ["derive"], optional = true }
 derive_more = { version = "2.0.1", features = [
-    "add",
-    "display",
-    "from",
-    "from_str",
-    "is_variant",
-    "try_into",
+  "add",
+  "display",
+  "from",
+  "from_str",
+  "is_variant",
+  "try_into",
 ] }
 dunce = "1.0.5"
 fastrand = "2.3.0"
@@ -50,20 +48,24 @@ solar-parse = { version = "0.1.4", default-features = false, optional = true }
 thiserror = "2.0.11"
 thiserror-ext = "0.3.0"
 wide = "1.1.1"
-winnow = "0.7.2"
+winnow = { version = "1.0.2", default-features = false, features = [
+  "ascii",
+  "std"
+] }
 zerocopy = "0.8.27"
 
 [dev-dependencies]
-divan = { version = "4.0.5", package = "codspeed-divan-compat" }
+divan = { package = "codspeed-divan-compat", version = "4.0.5" }
 insta = "1.42.1"
 miette = { version = "7.5.0", features = ["fancy"] }
-similar-asserts = "1.6.1"
+similar-asserts = "2.0.0"
 temp-dir = "0.2.0"
 
-[[bench]]
-name = "parser"
-harness = false
+[features]
+default = ["solar"]
+clap = ["dep:clap"]
+slang = ["dep:regex", "dep:slang_solidity"]
+solar = ["dep:solar-parse"]
 
-[[bench]]
-name = "lint"
-harness = false
+[lints]
+workspace = true

--- a/crates/lintspec-core/README.md
+++ b/crates/lintspec-core/README.md
@@ -18,7 +18,7 @@
   /></a>
   <a href="https://docs.rs/lintspec-core/latest/lintspec_core/"><img
       alt="MSRV"
-      src="https://img.shields.io/badge/MSRV-1.89.0-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
+      src="https://img.shields.io/badge/MSRV-1.94.1-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
       height="20"
   /></a>
   <a href="https://codspeed.io/beeb/lintspec"><img

--- a/crates/lintspec-macros/Cargo.toml
+++ b/crates/lintspec-macros/Cargo.toml
@@ -1,23 +1,22 @@
 [package]
 name = "lintspec-macros"
 version = "0.2.4"
+edition.workspace = true
+rust-version.workspace = true
 description = "Convenience macros for lintspec"
 readme = "./README.md"
-authors.workspace = true
-categories.workspace = true
-edition.workspace = true
-license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
-
-[lints]
-workspace = true
+license.workspace = true
+categories.workspace = true
 
 [lib]
 proc-macro = true
 
 [dependencies]
 unsynn = { version = "0.3.0", default-features = false, features = [
-    "docgen",
-    "proc_macro2",
+  "docgen",
+  "proc_macro2",
 ] }
+
+[lints]
+workspace = true

--- a/crates/lintspec-macros/README.md
+++ b/crates/lintspec-macros/README.md
@@ -18,7 +18,7 @@
   /></a>
   <a href="https://docs.rs/lintspec-macros/latest/lintspec_macros/"><img
       alt="MSRV"
-      src="https://img.shields.io/badge/MSRV-1.89.0-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
+      src="https://img.shields.io/badge/MSRV-1.94.1-b83fbf?style=flat&labelColor=555555&logo=docs.rs"
       height="20"
   /></a>
   <a href="https://codspeed.io/beeb/lintspec"><img

--- a/crates/lintspec/Cargo.toml
+++ b/crates/lintspec/Cargo.toml
@@ -1,23 +1,18 @@
 [package]
 name = "lintspec"
 version = "0.16.0"
-description = "A blazingly fast linter for NatSpec comments in Solidity code"
-keywords = ["natspec", "solidity", "linter", "checker", "documentation"]
-authors.workspace = true
-categories.workspace = true
 edition.workspace = true
-license.workspace = true
+rust-version.workspace = true
+description = "A blazingly fast linter for NatSpec comments in Solidity code"
 readme.workspace = true
 repository.workspace = true
-rust-version.workspace = true
+license.workspace = true
+keywords = ["checker", "documentation", "linter", "natspec", "solidity"]
+categories.workspace = true
 
-[lints]
-workspace = true
-
-[features]
-default = ["solar"]
-solar = ["lintspec-core/solar"]
-slang = ["lintspec-core/slang"]
+[[bench]]
+harness = false
+name = "e2e"
 
 [dependencies]
 clap = { version = "4.5.29", features = ["derive"] }
@@ -26,7 +21,7 @@ dotenvy = "0.15.7"
 dunce = "1.0.5"
 figment = { version = "0.10.19", features = ["env", "toml"] }
 lintspec-core = { path = "../lintspec-core", version = "0.16.0", default-features = false, features = [
-    "clap",
+  "clap",
 ] }
 miette = { version = "7.5.0", features = ["fancy"] }
 rayon = "1.10.0"
@@ -34,9 +29,13 @@ serde_json = "1.0.138"
 toml = "1.0.6"
 
 [dev-dependencies]
-divan = { version = "4.0.5", package = "codspeed-divan-compat" }
+divan = { package = "codspeed-divan-compat", version = "4.0.5" }
 temp-dir = "0.2.0"
 
-[[bench]]
-name = "e2e"
-harness = false
+[features]
+default = ["solar"]
+slang = ["lintspec-core/slang"]
+solar = ["lintspec-core/solar"]
+
+[lints]
+workspace = true

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1777488689,
-        "narHash": "sha256-UYE+SRTDdhXz/y9wmtibVyNapdQF7KCKa1w0Aw3bT7U=",
+        "lastModified": 1778401511,
+        "narHash": "sha256-QMHQy1xiNUug/xig3/BgZkNG/9t5HTOJsSd+376GIA8=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "ed56ade264bdc3294f457b472cb0482fc36f105c",
+        "rev": "1f07645938873d7027855d2564faaac36c4ceb76",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777270315,
-        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777399820,
-        "narHash": "sha256-S9efKWyWdEXBxItqalexMVgcWlcVH52GCu4pw3amb0w=",
+        "lastModified": 1778369049,
+        "narHash": "sha256-HvNEoAqcd7+VNyesjsy32pFjKdADd5dpTn4iV2teKDY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "561d1dd862573b5763064f5402511eecce69fc7a",
+        "rev": "e708e55b949b9c1a181d77b6fe62ab4e5b141526",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The latest version of `slang_solidity` (which adds support for solidity 0.8.35) requires at least rust 1.94.0, so I bumped the MSRV to 1.94.1 and updated dependencies.